### PR TITLE
Style route line in NavigationViewController

### DIFF
--- a/Navigation-Examples/Constants.swift
+++ b/Navigation-Examples/Constants.swift
@@ -104,5 +104,12 @@ let listOfExamples: [NamedController] = [
         controller: RouteLineStylingViewController.self,
         storyboard: nil,
         pushExampleToViewController: true
+    ),
+    (
+        name: "Turn-by-Turn Route Line Styling",
+        description: "Demonstrates how to style route lines in turn-by-turn navigation mode using appearance methods to override the traffic coloring defaults. Long press on the map to begin.",
+        controller: NavigationViewRouteLineStylingViewController.self,
+        storyboard: nil,
+        pushExampleToViewController: true
     )
 ]

--- a/Navigation-Examples/Examples/Navigation-View-Route-Styling.swift
+++ b/Navigation-Examples/Examples/Navigation-View-Route-Styling.swift
@@ -1,0 +1,153 @@
+import UIKit
+import MapboxCoreNavigation
+import MapboxNavigation
+import MapboxDirections
+import Mapbox
+
+
+class NavigationViewRouteLineStylingViewController: UIViewController, MGLMapViewDelegate, CLLocationManagerDelegate, NavigationMapViewDelegate, NavigationViewControllerDelegate {
+    
+    var mapView: NavigationMapView?
+    var routeOptions: NavigationRouteOptions?
+    var currentRoute: Route? {
+        get {
+            return routes?.first
+        }
+        set {
+            guard let selected = newValue else { routes?.remove(at: 0); return }
+            guard let routes = routes else { self.routes = [selected]; return }
+            self.routes = [selected] + routes.filter { $0 != selected }
+        }
+    }
+    var routes: [Route]? {
+        didSet {
+            guard let routes = routes, let current = routes.first else { mapView?.removeRoutes(); return }
+            mapView?.show(routes)
+            mapView?.showWaypoints(on: current)
+        }
+    }
+    var startButton: UIButton?
+    var locationManager = CLLocationManager()
+    
+    private typealias RouteRequestSuccess = (([Route]) -> Void)
+    private typealias RouteRequestFailure = ((NSError) -> Void)
+    
+    //MARK: - Lifecycle Methods
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        locationManager.delegate = self
+        locationManager.requestWhenInUseAuthorization()
+        
+        mapView = NavigationMapView(frame: view.bounds)
+        mapView?.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        mapView?.userTrackingMode = .follow
+        mapView?.delegate = self
+        mapView?.navigationMapViewDelegate = self
+        
+        let gesture = UILongPressGestureRecognizer(target: self, action: #selector(handleLongPress(_:)))
+        mapView?.addGestureRecognizer(gesture)
+        
+        view.addSubview(mapView!)
+        
+        startButton = UIButton()
+        startButton?.setTitle("Start Navigation", for: .normal)
+        startButton?.translatesAutoresizingMaskIntoConstraints = false
+        startButton?.backgroundColor = .blue
+        startButton?.contentEdgeInsets = UIEdgeInsets(top: 10, left: 20, bottom: 10, right: 20)
+        startButton?.addTarget(self, action: #selector(tappedButton(sender:)), for: .touchUpInside)
+        startButton?.isHidden = true
+        view.addSubview(startButton!)
+        startButton?.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor, constant: -20).isActive = true
+        startButton?.centerXAnchor.constraint(equalTo: self.view.centerXAnchor).isActive = true
+        view.setNeedsLayout()
+    }
+    
+    //overriding layout lifecycle callback so we can style the start button
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        startButton?.layer.cornerRadius = startButton!.bounds.midY
+        startButton?.clipsToBounds = true
+        startButton?.setNeedsDisplay()
+        
+    }
+
+    @objc func tappedButton(sender: UIButton) {
+        guard let route = currentRoute, let routeOptions = routeOptions else { return }
+        // For demonstration purposes, simulate locations if the Simulate Navigation option is on.
+        let navigationService = MapboxNavigationService(route: route, routeIndex: 0, routeOptions: routeOptions, simulating: simulationIsEnabled ? .always : .onPoorGPS)
+        
+        // Set the custom turn-by-turn style with NavigationOptions
+        let navigationOptions = NavigationOptions(styles: [CustomRouteLineStyle()], navigationService: navigationService)
+        let navigationViewController = NavigationViewController(for: route, routeIndex: 0, routeOptions: routeOptions, navigationOptions: navigationOptions)
+        navigationViewController.delegate = self
+        
+        // Render the passed portion of the route with full transparency
+        navigationViewController.routeLineTracksTraversal = true
+        navigationViewController.modalPresentationStyle = .fullScreen
+        
+        present(navigationViewController, animated: true, completion: nil)
+    }
+    
+     @objc func handleLongPress(_ gesture: UILongPressGestureRecognizer) {
+        guard gesture.state == .ended else { return }
+        
+        let spot = gesture.location(in: mapView)
+        guard let location = mapView?.convert(spot, toCoordinateFrom: mapView) else { return }
+        
+        requestRoute(destination: location)
+    }
+
+    func requestRoute(destination: CLLocationCoordinate2D) {
+        guard let userLocation = mapView?.userLocation!.location else { return }
+        let userWaypoint = Waypoint(location: userLocation, heading: mapView?.userLocation?.heading, name: "user")
+        let destinationWaypoint = Waypoint(coordinate: destination)
+        
+        let routeOptions = NavigationRouteOptions(waypoints: [userWaypoint, destinationWaypoint])
+        
+        Directions.shared.calculate(routeOptions) { [weak self] (session, result) in
+            switch result {
+            case .failure(let error):
+                print(error.localizedDescription)
+            case .success(let response):
+                guard let routes = response.routes, let strongSelf = self else {
+                    return
+                }
+                strongSelf.routeOptions = routeOptions
+                strongSelf.routes = routes
+                strongSelf.startButton?.isHidden = false
+                strongSelf.mapView?.show(routes)
+                strongSelf.mapView?.showWaypoints(on: strongSelf.currentRoute!)
+            }
+        }
+    }
+    
+    // Delegate method called when the user selects a route
+    func navigationMapView(_ mapView: NavigationMapView, didSelect route: Route) {
+        self.currentRoute = route
+    }
+    
+    func navigationViewControllerDidDismiss(_ navigationViewController: NavigationViewController, byCanceling canceled: Bool) {
+        dismiss(animated: true, completion: nil)
+    }
+}
+
+class CustomRouteLineStyle: DayStyle {
+    required init() {
+        super.init()
+        mapStyleURL = URL(string: "mapbox://styles/mapbox/dark-v10")!
+        styleType = .day
+    }
+    
+    // Override individual traffic level colors to change the route line appearance in turn-by-turn mode
+    // To make the route line one color set all of the traffic layers to that color
+    override func apply() {
+        super.apply()
+        NavigationMapView.appearance().trafficLowColor = UIColor.purple
+        NavigationMapView.appearance().trafficModerateColor = UIColor.purple
+        NavigationMapView.appearance().trafficHeavyColor = UIColor.purple
+        NavigationMapView.appearance().trafficSevereColor = UIColor.purple
+        NavigationMapView.appearance().trafficUnknownColor = UIColor.purple
+        NavigationMapView.appearance().routeCasingColor = UIColor.green
+    }
+}

--- a/Podfile
+++ b/Podfile
@@ -1,8 +1,7 @@
 platform :ios, '10.0'
 use_frameworks!
 
-pod 'MapboxCoreNavigation', :git => 'https://github.com/mapbox/mapbox-navigation-ios.git', :tag => 'v1.2.0-alpha.3'
-pod 'MapboxNavigation', :git => 'https://github.com/mapbox/mapbox-navigation-ios.git', :tag => 'v1.2.0-alpha.3'
+pod 'MapboxNavigation', '~> 1.2'
 
 target 'Navigation-Examples' do
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,78 +1,63 @@
 PODS:
   - Mapbox-iOS-SDK (6.3.0):
     - MapboxMobileEvents (~> 0.10.4)
-  - MapboxAccounts (2.3.0)
-  - MapboxCommon (7.1.2)
-  - MapboxCoreNavigation (1.2.0-alpha.3):
+  - MapboxAccounts (2.3.1)
+  - MapboxCommon (9.1.0)
+  - MapboxCoreNavigation (1.2.0):
     - MapboxAccounts (~> 2.3.0)
-    - MapboxDirections (~> 1.0)
+    - MapboxDirections (~> 1.2.0)
     - MapboxMobileEvents (~> 0.10.2)
-    - MapboxNavigationNative (~> 22.0)
+    - MapboxNavigationNative (~> 29.0)
     - Turf (~> 1.0)
-  - MapboxDirections (1.1.0):
+  - MapboxDirections (1.2.0):
     - Polyline (~> 5.0)
     - Turf (~> 1.0)
   - MapboxMobileEvents (0.10.7)
-  - MapboxNavigation (1.2.0-alpha.3):
+  - MapboxNavigation (1.2.0):
     - Mapbox-iOS-SDK (~> 6.0)
-    - MapboxCoreNavigation (= 1.2.0-alpha.3)
+    - MapboxCoreNavigation (= 1.2.0)
     - MapboxMobileEvents (~> 0.10.2)
     - MapboxSpeech (~> 1.0)
     - Solar (~> 2.1)
-  - MapboxNavigationNative (22.0.5):
-    - MapboxCommon (= 7.1.2)
+  - MapboxNavigationNative (29.0.0):
+    - MapboxCommon (= 9.1.0)
   - MapboxSpeech (1.0.0)
   - Polyline (5.0.2)
   - Solar (2.1.0)
-  - Turf (1.1.0)
+  - Turf (1.2.0)
 
 DEPENDENCIES:
-  - MapboxCoreNavigation (from `https://github.com/mapbox/mapbox-navigation-ios.git`, tag `v1.2.0-alpha.3`)
-  - MapboxNavigation (from `https://github.com/mapbox/mapbox-navigation-ios.git`, tag `v1.2.0-alpha.3`)
+  - MapboxNavigation (~> 1.2)
 
 SPEC REPOS:
   trunk:
     - Mapbox-iOS-SDK
     - MapboxAccounts
     - MapboxCommon
+    - MapboxCoreNavigation
     - MapboxDirections
     - MapboxMobileEvents
+    - MapboxNavigation
     - MapboxNavigationNative
     - MapboxSpeech
     - Polyline
     - Solar
     - Turf
 
-EXTERNAL SOURCES:
-  MapboxCoreNavigation:
-    :git: https://github.com/mapbox/mapbox-navigation-ios.git
-    :tag: v1.2.0-alpha.3
-  MapboxNavigation:
-    :git: https://github.com/mapbox/mapbox-navigation-ios.git
-    :tag: v1.2.0-alpha.3
-
-CHECKOUT OPTIONS:
-  MapboxCoreNavigation:
-    :git: https://github.com/mapbox/mapbox-navigation-ios.git
-    :tag: v1.2.0-alpha.3
-  MapboxNavigation:
-    :git: https://github.com/mapbox/mapbox-navigation-ios.git
-    :tag: v1.2.0-alpha.3
-
 SPEC CHECKSUMS:
   Mapbox-iOS-SDK: 6a67397df2bcafe5d2851604192aa8de6f8d6c89
-  MapboxAccounts: 84abfdde95d9dc483f604c1b0fe1861edf691ce7
-  MapboxCommon: e469f6c62de29e1906c37e0bce65f6826e7fb9ac
-  MapboxCoreNavigation: bc0dc2f48ad7a8551039095fc6dc1ae530c24a86
-  MapboxDirections: f47e5648051967c502897cf808090874e3f81c5d
+  MapboxAccounts: e40ef575df5d8b7ef33d0504ff2d393f4fde0455
+  MapboxCommon: 2de699add978635b5373f6e1ace3d10df12b8459
+  MapboxCoreNavigation: c2eea775aea994519dfc5192d51a0035f6f81376
+  MapboxDirections: 383df0cd65784897c2269750a42d9654c832f0ce
   MapboxMobileEvents: d0a581dedd8f47411cc65ea520b965e83914316e
-  MapboxNavigation: 9b7d154a6d79e49c7867d40e797d014a24d7e0c0
-  MapboxNavigationNative: 88f243e0460fc7d1d50035bf13583355da6e4c26
+  MapboxNavigation: 9a0d5b0df90e51dfac94682fd13f782ba996b84f
+  MapboxNavigationNative: 6a875fda10f89fdd48046abe5712494dba08855f
   MapboxSpeech: 4b3aea42e35d056fae1d7ad847a9fc0f412d911e
   Polyline: fce41d72e1146c41c6d081f7656827226f643dff
   Solar: 2dc6e7cc39186cb0c8228fa08df76fb50c7d8f24
-  Turf: 62a818ddce6c1af8d54da9d56232088d170ab27b
+  Turf: aaa060138b11a8e979a19e6d81091d156a31bc58
 
-PODFILE CHECKSUM: 75a9c39f9ae055b6c60959f291b60d70a4fc28b4
+PODFILE CHECKSUM: 00434525b0928e2ca7ed3f17e81d4eba65309174
 
-COCOAPODS: 1.10.0.rc.1
+COCOAPODS: 1.10.1


### PR DESCRIPTION
Adds new example to close https://github.com/mapbox/navigation-ios-examples/issues/84

This example demonstrates how to style route lines in turn-by-turn navigation mode using appearance methods to override the traffic coloring defaults. This example is based on the Advanced example from this repo. 

<img src="https://user-images.githubusercontent.com/7976026/106676671-59685e80-6585-11eb-9272-cd830092be72.png" width="250" />
