### PR TITLE
Add examples of predictive caching and route alerts to NavSDK v2.0

### DIFF
--- a/Navigation-Examples.xcodeproj/project.pbxproj
+++ b/Navigation-Examples.xcodeproj/project.pbxproj
@@ -26,6 +26,8 @@
 		9639244A22E02A520010FE73 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C58FB85D1FE899B800C4B491 /* Main.storyboard */; };
 		9639244B22E02A820010FE73 /* EmbeddedExamples.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8D6D36A620001F0400C2B61B /* EmbeddedExamples.storyboard */; };
 		B40ADDC9ABB7E7F6703997CA /* Pods_DocsCode.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9B796D93B6E7934BFD326FA8 /* Pods_DocsCode.framework */; };
+		B480E424261E4C3500C16FA0 /* Predictive-Caching.swift in Sources */ = {isa = PBXBuildFile; fileRef = B480E423261E4C3500C16FA0 /* Predictive-Caching.swift */; };
+		B480E428261E4C4600C16FA0 /* Route-Alerts.swift in Sources */ = {isa = PBXBuildFile; fileRef = B480E427261E4C4600C16FA0 /* Route-Alerts.swift */; };
 		C3893F1C25F96BDC0058A987 /* Custom-Waypoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3893F1B25F96BDC0058A987 /* Custom-Waypoints.swift */; };
 		C52BAA782040D5030086EC6B /* Custom-Destination-Marker.swift in Sources */ = {isa = PBXBuildFile; fileRef = C52BAA772040D5030086EC6B /* Custom-Destination-Marker.swift */; };
 		C58FB85A1FE899B800C4B491 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C58FB8591FE899B800C4B491 /* AppDelegate.swift */; };
@@ -68,6 +70,8 @@
 		9A4F31D3A4350E716451A486 /* Pods-DocsCode.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DocsCode.debug.xcconfig"; path = "Pods/Target Support Files/Pods-DocsCode/Pods-DocsCode.debug.xcconfig"; sourceTree = "<group>"; };
 		9B796D93B6E7934BFD326FA8 /* Pods_DocsCode.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_DocsCode.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B33B5E4C0AD283368D51EEDA /* Pods-DocsCode.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DocsCode.release.xcconfig"; path = "Pods/Target Support Files/Pods-DocsCode/Pods-DocsCode.release.xcconfig"; sourceTree = "<group>"; };
+		B480E423261E4C3500C16FA0 /* Predictive-Caching.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Predictive-Caching.swift"; sourceTree = "<group>"; };
+		B480E427261E4C4600C16FA0 /* Route-Alerts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Route-Alerts.swift"; sourceTree = "<group>"; };
 		BFEC70FB9C884A4DDD80E7D9 /* Pods-Navigation-Examples.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Navigation-Examples.release.xcconfig"; path = "Pods/Target Support Files/Pods-Navigation-Examples/Pods-Navigation-Examples.release.xcconfig"; sourceTree = "<group>"; };
 		C3893F1B25F96BDC0058A987 /* Custom-Waypoints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Custom-Waypoints.swift"; sourceTree = "<group>"; };
 		C52BAA772040D5030086EC6B /* Custom-Destination-Marker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Custom-Destination-Marker.swift"; sourceTree = "<group>"; };
@@ -224,6 +228,8 @@
 				8A96379A2492B366008DEF2A /* Route-Deserialization.swift */,
 				8AC9129C2494106100B6941E /* Route-Initialization.swift */,
 				8A33629524E4844E0086C647 /* Building-Extrusion.swift */,
+				B480E423261E4C3500C16FA0 /* Predictive-Caching.swift */,
+				B480E427261E4C4600C16FA0 /* Route-Alerts.swift */,
 				11DC36F126161DAF0042CD4A /* Location-Snapping.swift */,
 				8AC9129E2494118400B6941E /* TestData */,
 				2B521D5324094F2500984CF8 /* CustomBars */,
@@ -524,11 +530,13 @@
 				C5F130A01FE9B44600463E86 /* Constants.swift in Sources */,
 				11DC36F226161DAF0042CD4A /* Location-Snapping.swift in Sources */,
 				C58FB86E1FE89D9500C4B491 /* ExampleTableViewController.swift in Sources */,
+				B480E424261E4C3500C16FA0 /* Predictive-Caching.swift in Sources */,
 				C5C0D63820589422003A3B1D /* Custom-Server.swift in Sources */,
 				C3893F1C25F96BDC0058A987 /* Custom-Waypoints.swift in Sources */,
 				2B521D4E24090A3A00984CF8 /* CustomBarsViewController.swift in Sources */,
 				8A96379C2492B366008DEF2A /* Route-Deserialization.swift in Sources */,
 				2B521D502409240E00984CF8 /* CustomBottomBannerView.swift in Sources */,
+				B480E428261E4C4600C16FA0 /* Route-Alerts.swift in Sources */,
 				C58FB8771FE98B0E00C4B491 /* Waypoint-Arrival-Screen.swift in Sources */,
 				C5F130A61FEB2D7800463E86 /* Advanced.swift in Sources */,
 				C58FB86C1FE89CEC00C4B491 /* ExampleContainerViewController.swift in Sources */,

--- a/Navigation-Examples/Constants.swift
+++ b/Navigation-Examples/Constants.swift
@@ -106,6 +106,20 @@ let listOfExamples: [NamedController] = [
         pushExampleToViewController: true
     ),
     (
+        name: "Predictive Caching",
+        description: "Demonstrates how to use predictive caching for navigation.",
+        controller: PredictiveCachingViewController.self,
+        storyboard: nil,
+        pushExampleToViewController: false
+    ),
+    (
+        name: "Route Alerts",
+        description: "Demonstrates how to display route alerts.",
+        controller: RouteAlertsViewController.self,
+        storyboard: nil,
+        pushExampleToViewController: false
+    ),
+    (
         name: "Snapping locations in standalone map view",
         description: "Demonstrates how to snap user location to the road network in a map view outside of active turn-by-turn navigation. Simulate Navigation option isn't supported here, instead you can use location simulation inside of the Simulator (Features ‣ Location ‣ \"City Bicycle Ride\") to see the difference with and without snapping.",
         controller: LocationSnappingViewController.self,

--- a/Navigation-Examples/Examples/Predictive-Caching.swift
+++ b/Navigation-Examples/Examples/Predictive-Caching.swift
@@ -1,0 +1,46 @@
+import UIKit
+import MapboxCoreNavigation
+import MapboxNavigation
+import MapboxDirections
+
+class PredictiveCachingViewController: UIViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        let origin = CLLocationCoordinate2DMake(37.77440680146262, -122.43539772352648)
+        let destination = CLLocationCoordinate2DMake(37.76556957793795, -122.42409811526268)
+        let options = NavigationRouteOptions(coordinates: [origin, destination])
+        
+        Directions.shared.calculate(options) { [weak self] (session, result) in
+            switch result {
+            case .failure(let error):
+                print(error.localizedDescription)
+            case .success(let response):
+                guard let route = response.routes?.first, let strongSelf = self else {
+                    return
+                }
+                
+                // For demonstration purposes, simulate locations if the Simulate Navigation option is on.
+                // Since first route is retrieved from response `routeIndex` is set to 0.
+                let navigationService = MapboxNavigationService(route: route, routeIndex: 0, routeOptions: options, simulating: simulationIsEnabled ? .always : .onPoorGPS)
+                
+                // When predictive caching is enabled, the Navigation SDK will create a cache of data within three configurable boundaries.
+                var predictiveCacheOptions = PredictiveCacheOptions()
+                // Radius around the user's location. Defaults to 2000 meters.
+                predictiveCacheOptions.routeBufferRadius = 300
+                // Buffer around the route. Defaults to 500 meters.
+                predictiveCacheOptions.currentLocationRadius = 2000
+                // Radius around the destination. Defaults to 5000 meters.
+                predictiveCacheOptions.destinationLocationRadius = 3000
+                
+                let navigationOptions = NavigationOptions(navigationService: navigationService, predictiveCacheOptions: predictiveCacheOptions)
+
+                let navigationViewController = NavigationViewController(for: route, routeIndex: 0, routeOptions: options, navigationOptions: navigationOptions)
+                navigationViewController.modalPresentationStyle = .fullScreen
+                navigationViewController.routeLineTracksTraversal = true
+                
+                strongSelf.present(navigationViewController, animated: true)
+            }
+        }
+    }
+}

--- a/Navigation-Examples/Examples/Route-Alerts.swift
+++ b/Navigation-Examples/Examples/Route-Alerts.swift
@@ -1,0 +1,166 @@
+import UIKit
+import MapboxCoreNavigation
+import MapboxNavigation
+import MapboxDirections
+import MapboxNavigationNative
+
+class RouteAlertsViewController: UIViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        let origin = CLLocationCoordinate2DMake(37.789811651648456, -122.47075850058)
+        let destination = CLLocationCoordinate2DMake(37.79727245401114, -122.46951395567203)
+        let options = NavigationRouteOptions(coordinates: [origin, destination])
+        
+        Directions.shared.calculate(options) { [weak self] (session, result) in
+            switch result {
+            case .failure(let error):
+                print(error.localizedDescription)
+            case .success(let response):
+                guard let route = response.routes?.first, let strongSelf = self else {
+                    return
+                }
+                
+                // For demonstration purposes, simulate locations if the Simulate Navigation option is on.
+                let navigationService = MapboxNavigationService(route: route, routeIndex: 0, routeOptions: options, simulating: simulationIsEnabled ? .always : .onPoorGPS)
+                
+                // Define a customized `topBanner` to display route alerts during turn-by-turn navigation, and pass it to `NavigationOptions`.
+                let topAlertsBannerViewController = TopAlertsBarViewController()
+                let navigationOptions = NavigationOptions(navigationService: navigationService, topBanner: topAlertsBannerViewController)
+                let navigationViewController = NavigationViewController(for: route, routeIndex: 0, routeOptions: options, navigationOptions: navigationOptions)
+
+                let parentSafeArea = navigationViewController.view.safeAreaLayoutGuide
+                topAlertsBannerViewController.view.topAnchor.constraint(equalTo: parentSafeArea.topAnchor).isActive = true
+                
+                navigationViewController.modalPresentationStyle = .fullScreen
+                
+                strongSelf.present(navigationViewController, animated: true)
+            }
+        }
+    }
+}
+
+// MARK: - TopAlertsBarViewController
+class TopAlertsBarViewController: ContainerViewController {
+    
+    lazy var topAlertsBannerView: InstructionsBannerView = {
+        let banner = InstructionsBannerView()
+        banner.translatesAutoresizingMaskIntoConstraints = false
+        banner.layer.cornerRadius = 25
+        banner.layer.opacity = 0.8
+        return banner
+    }()
+    
+    override func viewDidLoad() {
+        view.addSubview(topAlertsBannerView)
+        setupConstraints()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        setupConstraints()
+    }
+    
+    private func setupConstraints() {
+        
+        // To change top banner size and position change layout constraints directly.
+        let topAlertsBannerViewConstraints: [NSLayoutConstraint] = [
+            topAlertsBannerView.topAnchor.constraint(equalTo: view.topAnchor, constant: 10),
+            topAlertsBannerView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 60),
+            topAlertsBannerView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -60),
+            topAlertsBannerView.heightAnchor.constraint(equalToConstant: 100.0),
+            topAlertsBannerView.centerXAnchor.constraint(equalTo: view.centerXAnchor)
+        ]
+        NSLayoutConstraint.activate(topAlertsBannerViewConstraints)
+    }
+    
+    open override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        setupConstraints()
+    }
+    
+    public func updateAlerts(alerts: [String]) {
+        
+        // Change the property of`primaryLabel: InstructionLabel`.
+        let text = alerts.joined(separator: "\n")
+        topAlertsBannerView.primaryLabel.text = text
+        topAlertsBannerView.primaryLabel.numberOfLines = 0
+        topAlertsBannerView.primaryLabel.lineBreakMode = NSLineBreakMode.byWordWrapping
+    }
+    
+    // MARK: - NavigationServiceDelegate implementation
+    
+    public func navigationService(_ service: NavigationService, didPassVisualInstructionPoint instruction: VisualInstructionBanner, routeProgress: RouteProgress) {
+        topAlertsBannerView.update(for: instruction)
+    }
+    
+    public func navigationService(_ service: NavigationService, didRerouteAlong route: Route, at location: CLLocation?, proactive: Bool) {
+        topAlertsBannerView.updateDistance(for: service.routeProgress.currentLegProgress.currentStepProgress)
+    }
+    
+    public func navigationService(_ service: NavigationService, didUpdate progress: RouteProgress, with location: CLLocation, rawLocation: CLLocation) {
+        topAlertsBannerView.updateDistance(for: service.routeProgress.currentLegProgress.currentStepProgress)
+        let allAlerts = progress.upcomingRouteAlerts.filter({ !$0.description.isEmpty }).map({ $0.description })
+        if !allAlerts.isEmpty {
+            updateAlerts(alerts: allAlerts)
+        } else {
+            // If there's no usable route alerts in the route progress, displaying `currentVisualInstruction` instead.
+            let instruction = progress.currentLegProgress.currentStepProgress.currentVisualInstruction
+            topAlertsBannerView.primaryLabel.lineBreakMode = NSLineBreakMode.byTruncatingTail
+            topAlertsBannerView.update(for: instruction)
+        }
+    }
+}
+
+// MARK: - MapboxCoreNavigation.RouteAlert to String implementation
+extension MapboxDirections.Incident: CustomStringConvertible {
+    
+    public var alertDescription: String {
+        guard let kind = self.kind else { return self.description }
+        if let impact = self.impact, let lanesBlocked = self.lanesBlocked {
+            return "A \(impact) \(kind) ahead blocking \(lanesBlocked)"
+        } else if let impact = self.impact {
+            return "A \(impact) \(kind) ahead"
+        } else {
+            return "A \(kind) ahead blocking \(self.lanesBlocked!)"
+        }
+    }
+}
+
+extension MapboxCoreNavigation.RouteAlert: CustomStringConvertible {
+    
+    public var description: String {
+        let distance = Int64(self.distanceToStart)
+        guard distance > 0 && distance < 500 else { return "" }
+        
+        let alertInfo = self.alert
+        switch alertInfo {
+        case .incident(let incident):
+            return "\(incident.alertDescription) in \(distance)m."
+        case .tunnel(let alert):
+            if let alertName = alert.name {
+                return "Tunnel \(alertName) in \(distance)m."
+            } else {
+                return "A tunnel in \(distance)m."
+            }
+        case .borderCrossing(let alert):
+            return "Crossing border from \(alert.from) to \(alert.to) in \(distance)m."
+        case .serviceArea(let alert):
+            switch alert.type {
+            case .restArea:
+                return "Rest area in \(distance)m."
+            case .serviceArea:
+                return "Service area in \(distance)m."
+            }
+        case .tollCollection(let alert):
+            switch alert.type {
+            case .booth:
+                return "Toll booth in \(distance)m."
+            case .gantry:
+                return "Toll gantry in \(distance)m."
+            }
+        default:
+            return ""
+        }
+    }
+}


### PR DESCRIPTION
This pr is to add missing examples to v2.0.

- [x] add predictive caching example.
- [x] Display route alerts

### Implementation
The route alerts will be displayed in the customized top banner. If there's no usable route alerts, it would show the instruction information instead.

### Screenshots or Gifs
![routeAlerts](https://user-images.githubusercontent.com/48976398/113453606-31e21680-93bb-11eb-94c6-882d93c3fd38.gif)
