### PR TITLE
Add offline regions example

### DIFF
--- a/Navigation-Examples.xcodeproj/project.pbxproj
+++ b/Navigation-Examples.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		B40ADDC9ABB7E7F6703997CA /* Pods_DocsCode.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9B796D93B6E7934BFD326FA8 /* Pods_DocsCode.framework */; };
 		B480E424261E4C3500C16FA0 /* Predictive-Caching.swift in Sources */ = {isa = PBXBuildFile; fileRef = B480E423261E4C3500C16FA0 /* Predictive-Caching.swift */; };
 		B480E428261E4C4600C16FA0 /* Route-Alerts.swift in Sources */ = {isa = PBXBuildFile; fileRef = B480E427261E4C4600C16FA0 /* Route-Alerts.swift */; };
+		C35F1E4D2656967E00EC54CD /* Offline-Regions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C35F1E4C2656967E00EC54CD /* Offline-Regions.swift */; };
 		C3893F1C25F96BDC0058A987 /* Custom-Waypoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3893F1B25F96BDC0058A987 /* Custom-Waypoints.swift */; };
 		C52BAA782040D5030086EC6B /* Custom-Destination-Marker.swift in Sources */ = {isa = PBXBuildFile; fileRef = C52BAA772040D5030086EC6B /* Custom-Destination-Marker.swift */; };
 		C58FB85A1FE899B800C4B491 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C58FB8591FE899B800C4B491 /* AppDelegate.swift */; };
@@ -87,6 +88,7 @@
 		B480E423261E4C3500C16FA0 /* Predictive-Caching.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Predictive-Caching.swift"; sourceTree = "<group>"; };
 		B480E427261E4C4600C16FA0 /* Route-Alerts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Route-Alerts.swift"; sourceTree = "<group>"; };
 		BFEC70FB9C884A4DDD80E7D9 /* Pods-Navigation-Examples.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Navigation-Examples.release.xcconfig"; path = "Pods/Target Support Files/Pods-Navigation-Examples/Pods-Navigation-Examples.release.xcconfig"; sourceTree = "<group>"; };
+		C35F1E4C2656967E00EC54CD /* Offline-Regions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Offline-Regions.swift"; sourceTree = "<group>"; };
 		C3893F1B25F96BDC0058A987 /* Custom-Waypoints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Custom-Waypoints.swift"; sourceTree = "<group>"; };
 		C52BAA772040D5030086EC6B /* Custom-Destination-Marker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Custom-Destination-Marker.swift"; sourceTree = "<group>"; };
 		C58FB8561FE899B800C4B491 /* Navigation-Examples.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Navigation-Examples.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -255,6 +257,7 @@
 				8D6D36A620001F0400C2B61B /* EmbeddedExamples.storyboard */,
 				C5F130A51FEB2D7800463E86 /* Advanced.swift */,
 				C59094C2203E3B9100EB2417 /* Custom-Voice-Controller.swift */,
+				C35F1E4C2656967E00EC54CD /* Offline-Regions.swift */,
 				C52BAA772040D5030086EC6B /* Custom-Destination-Marker.swift */,
 				C5C0D63720589422003A3B1D /* Custom-Server.swift */,
 				C3893F1B25F96BDC0058A987 /* Custom-Waypoints.swift */,
@@ -578,6 +581,7 @@
 				2B521D502409240E00984CF8 /* CustomBottomBannerView.swift in Sources */,
 				B480E428261E4C4600C16FA0 /* Route-Alerts.swift in Sources */,
 				C58FB8771FE98B0E00C4B491 /* Waypoint-Arrival-Screen.swift in Sources */,
+				C35F1E4D2656967E00EC54CD /* Offline-Regions.swift in Sources */,
 				C5F130A61FEB2D7800463E86 /* Advanced.swift in Sources */,
 				C58FB86C1FE89CEC00C4B491 /* ExampleContainerViewController.swift in Sources */,
 				8AC9129D2494106100B6941E /* Route-Initialization.swift in Sources */,

--- a/Navigation-Examples/Constants.swift
+++ b/Navigation-Examples/Constants.swift
@@ -153,12 +153,12 @@ let listOfExamples: [NamedController] = [
         controller: SegueViewController.self,
         storyboard: UIStoryboard(name: "CustomSegue", bundle: nil),
         pushExampleToViewController: true
+    ),
+    (
+        name: "Offline Regions",
+        description: "Demonstrates how to create a custom TileStore and handle offline regions.",
+        controller: OfflineRegionsViewController.self,
+        storyboard: nil,
+        pushExampleToViewController: true
     )
-//    (
-//        name: "Offline Regions",
-//        description: "Demonstrates how to create a custom TileStore and handle offline regions.",
-//        controller: OfflineRegionsViewController.self,
-//        storyboard: nil,
-//        pushExampleToViewController: true
-//    )
 ]

--- a/Navigation-Examples/Constants.swift
+++ b/Navigation-Examples/Constants.swift
@@ -154,4 +154,11 @@ let listOfExamples: [NamedController] = [
         storyboard: UIStoryboard(name: "CustomSegue", bundle: nil),
         pushExampleToViewController: true
     )
+//    (
+//        name: "Offline Regions",
+//        description: "Demonstrates how to create a custom TileStore and handle offline regions.",
+//        controller: OfflineRegionsViewController.self,
+//        storyboard: nil,
+//        pushExampleToViewController: true
+//    )
 ]

--- a/Navigation-Examples/Examples/Offline-Regions.swift
+++ b/Navigation-Examples/Examples/Offline-Regions.swift
@@ -1,0 +1,263 @@
+import UIKit
+import MapboxNavigation
+import MapboxCoreNavigation
+import MapboxMaps
+
+class OfflineRegionsViewController: UIViewController {
+
+    let accessToken = CredentialsManager.default.accessToken
+    var tileStore = TileStore.getInstance()
+    let resourceOptions: ResourceOptions!
+    
+    // Transition button, progress view
+    var stateButton: UIButton!
+    var tileRegionsTableView: UITableView!
+    var stylePackProgressView: UIProgressView!
+    var tileRegionProgressView: UIProgressView!
+    var progressContainer: UIView!
+    var downloadRegionsView: UIView!
+    
+    var navigationMapView: NavigationMapView!
+    
+    lazy var offlineManager: OfflineManager = {
+        return OfflineManager(resourceOptions: <#T##ResourceOptions#>)
+    }()
+    
+    // Tile region and style pack
+    var downloads: [Cancelable] = []
+    
+    // Create some hard-coded regions
+    let washingtonDCCoord = CLLocationCoordinate2D(latitude: 38.907, longitude: -77.036)
+    let washingtonDCZoom: CGFloat = 12
+    let dcRegionIdentifier = "Washington DC Tile Region"
+    
+    let sanFranCoord = CLLocationCoordinate2D(latitude: 37.791, longitude: -122.396)
+    let sanFranZoom: CGFloat = 12
+    let sfRegionIdentifier = "San Francisco Tile Region"
+    
+    enum State {
+        case beforeExampleSelected
+        case initial
+        case downloading
+        case downloaded
+        case finished
+        case showingNavigationMapView
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        state = .initial
+    }
+    
+    func setupRefreshRegionsBarButtonItem() {
+        let refreshRegionsBarButtonItem = UIBarButtonItem(title: NSString(string: "\u{1F5FA}") as String,
+                                                    style: .plain,
+                                                    target: self,
+                                                    action: #selector(updateRegions))
+        refreshRegionsBarButtonItem.setTitleTextAttributes([.font: UIFont.systemFont(ofSize: 30)], for: .normal)
+        refreshRegionsBarButtonItem.setTitleTextAttributes([.font: UIFont.systemFont(ofSize: 30)], for: .highlighted)
+        navigationItem.rightBarButtonItem = refreshRegionsBarButtonItem
+    }
+    
+    func setupTileRegionsTableView() {
+        tileRegionsTableView = UITableView()
+    }
+    
+// MARK: Offline Regions
+    @objc func updateRegions(_ sender: Any) {
+        refreshOutdatedOfflineRegions()
+    }
+    
+    @objc func listRegions(_ sender: Any) {
+        tileRegionsTableView.isHidden = false
+    }
+
+    func createCustomTileStore() {
+        // get access token
+        guard let accessToken = CredentialsManager.default.accessToken else {
+            fatalError("Access token was not set.")
+        }
+
+        // Create a TileStore instance at the default location
+        tileStore = TileStore.getInstance()
+        let resourceOptions = ResourceOptions(accessToken: accessToken,
+                                              tileStore: tileStore)
+    }
+
+    func downloadOfflineRegions() {
+        // Create style package
+        let stylePackLoadOptions = StylePackLoadOptions(glyphsRasterizationMode: .ideographsRasterizedLocally, metadata: nil)!
+        
+        
+        let stylePackDownload = offlineManager.loadStylePack(for: .streets, loadOptions: stylePackLoadOptions) { [weak self] progress in
+            // update UI
+            DispatchQueue.main.async {
+                guard let progress = progress,
+                      let stylePackProgressView = self?.stylePackProgressView
+                else {
+                    return
+                }
+                // Update style pack progress bar
+                stylePackProgressView.progress = Float(progress.completedResourceCount)/Float(progress.requiredResourceCount)
+            }
+        } completion: { [ weak self] result in
+            // Confirm successful download
+            switch result {
+            case .success(let stylePack):
+                print("Style pack \(stylePack.styleURI) downloaded!")
+            case .failure(let error):
+                print("Error while downloading style pack: \(error).")
+            }
+        }
+
+        
+        // Create offline regions with tiles
+        let navigationOptions = TilesetDescriptorOptions(styleURI: .streets, zoomRange: 0...10)
+        let navigationDescriptor = offlineManager.createTilesetDescriptor(for: navigationOptions)
+        
+        // Load tile region
+        let tileLoadOptions = TileLoadOptions(
+            criticalPriority: false,
+            acceptExpired: true,
+            networkRestriction: .none)
+        
+        let tileRegionLoadOptions = TileRegionLoadOptions(
+            geometry: MBXGeometry(coordinate: washingtonDCCoord),
+            descriptors: [navigationDescriptor],
+            metadata: nil,
+            tileLoadOptions: tileLoadOptions,
+            averageBytesPerSecond: nil)!
+                
+        let tileRegionDownload = tileStore.loadTileRegion(forId: dcRegionIdentifier, loadOptions: tileRegionLoadOptions) { [weak self] progress in
+            // Closure gets called from the TileStore thread, so we need to dispatch to the main queue to update the UI.
+            DispatchQueue.main.async {
+                guard let progress = progress,
+                      let tileRegionProgressView = self?.tileRegionProgressView
+                else {
+                    return
+                }
+                // Update tile region progress bar
+                tileRegionProgressView.progress = Float(progress.completedResourceCount)/Float(progress.requiredResourceCount)
+            }
+        } completion: { [weak self] result in
+            // Confirm successful download.
+            switch result {
+            case .success(let region):
+                print("Tile \(region.id) downloaded!")
+                self?.state = .downloaded
+            case .failure(let error):
+                print("Error while updating outdated regions: \(error).")
+            }
+        }
+        // Wait for download to finish
+//        DispatchQueue.main.async {
+//            let loadingCompleted = (region.completedResourceCount == region.requiredResourceCount)
+//            print("Offline region loading complete = \(loadingCompleted)")
+//            if loadingCompleted {
+//                self.state = .downloaded
+//            }
+//        }
+        downloads = [tileRegionDownload]
+    }
+    
+    func cancelDownloads() {
+        downloads.forEach { $0.cancel() }
+    }
+    
+    func showDownloadedRegions() {
+        
+    }
+
+    func listOfflineRegions() -> [TileRegion] {
+        var tiles: [TileRegion]
+        
+        tileStore.allTileRegions(completion: { result in
+            do {
+                tiles = try result.get()
+            } catch {
+                print("Error listing offline regions: \(error).")
+            }
+        })
+        
+        return tiles
+    }
+
+    // Updating a region is done by the same scenario as downloading a new one
+    func refreshOutdatedOfflineRegions() {
+        // refresh all existing regions
+        let tiles = listOfflineRegions()
+        tiles.forEach { tile in
+            // TODO: ADD TILEREGIONLOADOPTIONS HERE!
+            let regionLoadOptions = TileRegionLoadOptions()
+            tileStore.loadTileRegion(forId: tile.id, loadOptions: <#T##TileRegionLoadOptions#>, completion: { result in
+                switch result {
+                case .success(let region):
+                    print("Tile \(region.id) updated!")
+                case .failure(let error):
+                    print("Error while updating outdated regions: \(error).")
+                }
+            })
+        }
+    }
+
+    func removeOfflineRegion(for tile: TileRegion) {
+        tileStore.removeTileRegion(forId: tile.id)
+    }
+    
+// MARK: NavigationMapView Methods
+    func enableShowNavigationMapView(){
+        stateButton.setTitle("Show NavigationMapView", for: .normal)
+    }
+        
+    func showNavigationMapView() {
+        progressContainer.isHidden = true
+        downloadRegionsView.isHidden = true
+            
+        navigationMapView = NavigationMapView(frame: view.bounds)
+        navigationMapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        navigationMapView.mapView.update {
+            $0.location.puckType = .puck2D()
+        }
+
+        view.addSubview(navigationMapView)
+    }
+    
+// MARK: Handle State Changes
+    var state: State = .beforeExampleSelected {
+        didSet {
+            switch(oldValue, state) {
+            case(_, .initial):
+             print("Example started!")
+            case (.initial, .downloading):
+                // Add ability to cancel download
+                stateButton.setTitle("Cancel Download", for: .normal)
+            case (.downloading, .downloaded):
+                // Be able to display NavigationMapView
+                enableShowNavigationMapView()
+            case (.downloaded, .showingNavigationMapView):
+                showNavigationMapView()
+            case (.showingNavigationMapView, .finished):
+                stateButton.setTitle("Reset", for: .normal)
+            default:
+                fatalError("Invalid transition from \(oldValue) to \(state).")
+            }
+        }
+    }
+    
+    @objc func didTapStateButton(_ button: UIButton) {
+        switch state {
+        case .beforeExampleSelected:
+            state = .initial
+        case .initial:
+            downloadOfflineRegions()
+        case .downloading:
+            cancelDownloads()
+        case .downloaded:
+            state = .showingNavigationMapView
+        case .showingNavigationMapView:
+            showDownloadedRegions()
+        case .finished:
+            state = .initial
+        }
+    }
+}

--- a/Navigation-Examples/Examples/Offline-Regions.swift
+++ b/Navigation-Examples/Examples/Offline-Regions.swift
@@ -1,44 +1,77 @@
 import UIKit
-import MapboxNavigation
 import MapboxCoreNavigation
+import MapboxNavigation
+import MapboxDirections
 import MapboxMaps
 
-class OfflineRegionsViewController: UIViewController {
+class OfflineRegionsViewController: UIViewController, NavigationViewControllerDelegate {
 
-    let accessToken = CredentialsManager.default.accessToken
-    var tileStore = TileStore.getInstance()
-    let resourceOptions: ResourceOptions!
+    var tileStore: TileStore!
+    var resourceOptions: ResourceOptions!
     
     // Transition button, progress view
     var stateButton: UIButton!
-    var tileRegionsTableView: UITableView!
+//    var tileRegionsTableView: UITableView!
     var stylePackProgressView: UIProgressView!
     var tileRegionProgressView: UIProgressView!
-    var progressContainer: UIView!
     var downloadRegionsView: UIView!
     
+    var startButton: UIButton!
     var navigationMapView: NavigationMapView!
+    var navigationRouteOptions: NavigationRouteOptions!
     
-    lazy var offlineManager: OfflineManager = {
-        return OfflineManager(resourceOptions: <#T##ResourceOptions#>)
-    }()
+    var currentRoute: Route? {
+        get {
+            return routes?.first
+        }
+        set {
+            guard let selected = newValue else { routes = nil; return }
+            guard let routes = routes else { self.routes = [selected]; return }
+            self.routes = [selected] + routes.filter { $0 != selected }
+        }
+    }
+    
+    var routes: [Route]? {
+        didSet {
+            guard let routes = routes, let currentRoute = routes.first else {
+                navigationMapView.removeRoutes()
+                navigationMapView.removeWaypoints()
+                waypoints.removeAll()
+                return
+            }
+
+            navigationMapView.show(routes)
+            navigationMapView.showWaypoints(on: currentRoute)
+        }
+    }
+    
+    var waypoints: [Waypoint] = []
     
     // Tile region and style pack
     var downloads: [Cancelable] = []
     
     // Create some hard-coded regions
+    let tileZoom: CGFloat = 12
+    let tileAreas: [ToBeTileRegion] = [
+        ToBeTileRegion(coordinates: CLLocationCoordinate2D(latitude: 38.907, longitude: -77.036), identifier: "Washington DC Tile Region"),
+        ToBeTileRegion(coordinates: CLLocationCoordinate2D(latitude: 39.289, longitude: -76.613), identifier: "Baltimore Tile Region"),
+        ToBeTileRegion(coordinates: CLLocationCoordinate2D(latitude: 38.805, longitude: -77.046), identifier: "Alexandria Tile Region")
+    ]
     let washingtonDCCoord = CLLocationCoordinate2D(latitude: 38.907, longitude: -77.036)
-    let washingtonDCZoom: CGFloat = 12
     let dcRegionIdentifier = "Washington DC Tile Region"
     
-    let sanFranCoord = CLLocationCoordinate2D(latitude: 37.791, longitude: -122.396)
-    let sanFranZoom: CGFloat = 12
-    let sfRegionIdentifier = "San Francisco Tile Region"
+    var offlineManager: OfflineManager!
+    var mapInitOptions: MapInitOptions!
+    
+    struct ToBeTileRegion {
+        var coordinates: CLLocationCoordinate2D
+        var identifier: String
+    }
     
     enum State {
         case beforeExampleSelected
         case initial
-        case downloading
+//        case downloading
         case downloaded
         case finished
         case showingNavigationMapView
@@ -46,7 +79,71 @@ class OfflineRegionsViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        initialSetup()
         state = .initial
+    }
+    
+    func initialSetup() {
+        resourceOptions = createCustomTileStore()
+        offlineManager = OfflineManager(resourceOptions: resourceOptions)
+        mapInitOptions = MapInitOptions(resourceOptions: resourceOptions, cameraOptions: CameraOptions(center: washingtonDCCoord, zoom: tileZoom), styleURI: .streets)
+        
+        downloadRegionsView = UIView(frame: self.view.bounds)
+        downloadRegionsView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        view.addSubview(downloadRegionsView)
+        downloadRegionsView.backgroundColor = UIColor.white
+        
+        setupStateButton()
+        setupProgressViews()
+    }
+    
+    func setupStateButton() {
+        stateButton = UIButton()
+        stateButton.setTitle("Start Downloads", for: .normal)
+        stateButton.translatesAutoresizingMaskIntoConstraints = false
+        stateButton.backgroundColor = .blue
+        stateButton.contentEdgeInsets = UIEdgeInsets(top: 10, left: 20, bottom: 10, right: 20)
+        stateButton.isHidden = false
+        stateButton.addTarget(self, action: #selector(didTapStateButton(_:)), for: .touchUpInside)
+        view.addSubview(stateButton)
+        
+        stateButton.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor, constant: -20).isActive = true
+        stateButton.centerXAnchor.constraint(equalTo: self.view.centerXAnchor).isActive = true
+        view.setNeedsLayout()
+    }
+    
+    func setupStartButton() {
+        startButton = UIButton()
+        startButton.setTitle("Start Navigation", for: .normal)
+        startButton.translatesAutoresizingMaskIntoConstraints = false
+        startButton.backgroundColor = .blue
+        startButton.contentEdgeInsets = UIEdgeInsets(top: 10, left: 20, bottom: 10, right: 20)
+        startButton.addTarget(self, action: #selector(tappedStartButton(_:)), for: .touchUpInside)
+        startButton.isHidden = true
+        view.addSubview(startButton)
+        
+        startButton.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor, constant: -20).isActive = true
+        startButton.centerXAnchor.constraint(equalTo: self.view.centerXAnchor).isActive = true
+        view.setNeedsLayout()
+    }
+    
+    func setupProgressViews() {
+        stylePackProgressView = UIProgressView(frame: CGRect(x: 10, y: 200, width: view.frame.size.width-20, height: 20))
+        let stylePackProgressLabel = UILabel(frame: CGRect(x: 10, y: 150, width: view.frame.size.width-20, height: 20))
+        stylePackProgressLabel.bottomAnchor.constraint(equalTo: self.stylePackProgressView.topAnchor)
+        stylePackProgressLabel.text = "Style Pack"
+        view.addSubview(stylePackProgressView)
+        view.addSubview(stylePackProgressLabel)
+        stylePackProgressView.progress = 0.0
+        
+        tileRegionProgressView = UIProgressView(frame: CGRect(x: 10, y: 300, width: view.frame.size.width-20, height: 20))
+        let tileRegionProgressLabel = UILabel(frame: CGRect(x: 10, y: 250, width: view.frame.size.width-20, height: 20))
+        tileRegionProgressLabel.bottomAnchor.constraint(equalTo: self.tileRegionProgressView.topAnchor)
+        tileRegionProgressLabel.text = "Tile Region"
+        view.addSubview(tileRegionProgressView)
+        view.addSubview(tileRegionProgressLabel)
+        tileRegionProgressView.progress = 0.0
     }
     
     func setupRefreshRegionsBarButtonItem() {
@@ -59,20 +156,20 @@ class OfflineRegionsViewController: UIViewController {
         navigationItem.rightBarButtonItem = refreshRegionsBarButtonItem
     }
     
-    func setupTileRegionsTableView() {
-        tileRegionsTableView = UITableView()
-    }
-    
+//    func setupTileRegionsTableView() {
+//        tileRegionsTableView = UITableView()
+//    }
+//
 // MARK: Offline Regions
     @objc func updateRegions(_ sender: Any) {
         refreshOutdatedOfflineRegions()
     }
     
-    @objc func listRegions(_ sender: Any) {
-        tileRegionsTableView.isHidden = false
-    }
+//    @objc func listRegions(_ sender: Any) {
+//        tileRegionsTableView.isHidden = false
+//    }
 
-    func createCustomTileStore() {
+    func createCustomTileStore() -> ResourceOptions {
         // get access token
         guard let accessToken = CredentialsManager.default.accessToken else {
             fatalError("Access token was not set.")
@@ -80,7 +177,7 @@ class OfflineRegionsViewController: UIViewController {
 
         // Create a TileStore instance at the default location
         tileStore = TileStore.getInstance()
-        let resourceOptions = ResourceOptions(accessToken: accessToken,
+        return ResourceOptions(accessToken: accessToken,
                                               tileStore: tileStore)
     }
 
@@ -100,7 +197,7 @@ class OfflineRegionsViewController: UIViewController {
                 // Update style pack progress bar
                 stylePackProgressView.progress = Float(progress.completedResourceCount)/Float(progress.requiredResourceCount)
             }
-        } completion: { [ weak self] result in
+        } completion: { result in
             // Confirm successful download
             switch result {
             case .success(let stylePack):
@@ -138,38 +235,31 @@ class OfflineRegionsViewController: UIViewController {
                 }
                 // Update tile region progress bar
                 tileRegionProgressView.progress = Float(progress.completedResourceCount)/Float(progress.requiredResourceCount)
+//                self?.state = .downloading
             }
-        } completion: { [weak self] result in
+        } completion: { result in
             // Confirm successful download.
             switch result {
             case .success(let region):
                 print("Tile \(region.id) downloaded!")
-                self?.state = .downloaded
             case .failure(let error):
                 print("Error while updating outdated regions: \(error).")
             }
         }
-        // Wait for download to finish
-//        DispatchQueue.main.async {
-//            let loadingCompleted = (region.completedResourceCount == region.requiredResourceCount)
-//            print("Offline region loading complete = \(loadingCompleted)")
-//            if loadingCompleted {
-//                self.state = .downloaded
-//            }
-//        }
-        downloads = [tileRegionDownload]
+        downloads = [stylePackDownload, tileRegionDownload]
+        self.state = .downloaded
     }
     
-    func cancelDownloads() {
-        downloads.forEach { $0.cancel() }
-    }
+//    func cancelDownloads() {
+//        downloads.forEach { $0.cancel() }
+//    }
     
     func showDownloadedRegions() {
         
     }
 
     func listOfflineRegions() -> [TileRegion] {
-        var tiles: [TileRegion]
+        var tiles: [TileRegion] = []
         
         tileStore.allTileRegions(completion: { result in
             do {
@@ -186,10 +276,17 @@ class OfflineRegionsViewController: UIViewController {
     func refreshOutdatedOfflineRegions() {
         // refresh all existing regions
         let tiles = listOfflineRegions()
+        let tileLoadOptions = TileLoadOptions(
+            criticalPriority: false,
+            acceptExpired: true,
+            networkRestriction: .none)
+        
         tiles.forEach { tile in
-            // TODO: ADD TILEREGIONLOADOPTIONS HERE!
-            let regionLoadOptions = TileRegionLoadOptions()
-            tileStore.loadTileRegion(forId: tile.id, loadOptions: <#T##TileRegionLoadOptions#>, completion: { result in
+            let tileRegionLoadOptions = TileRegionLoadOptions(
+                geometry: MBXGeometry(coordinate: washingtonDCCoord),
+                tileLoadOptions: tileLoadOptions)!
+            
+            tileStore.loadTileRegion(forId: tile.id, loadOptions: tileRegionLoadOptions, completion: { result in
                 switch result {
                 case .success(let region):
                     print("Tile \(region.id) updated!")
@@ -207,10 +304,10 @@ class OfflineRegionsViewController: UIViewController {
 // MARK: NavigationMapView Methods
     func enableShowNavigationMapView(){
         stateButton.setTitle("Show NavigationMapView", for: .normal)
+        return
     }
         
     func showNavigationMapView() {
-        progressContainer.isHidden = true
         downloadRegionsView.isHidden = true
             
         navigationMapView = NavigationMapView(frame: view.bounds)
@@ -219,8 +316,60 @@ class OfflineRegionsViewController: UIViewController {
             $0.location.puckType = .puck2D()
         }
 
+        let navigationViewportDataSource = NavigationViewportDataSource(navigationMapView.mapView, viewportDataSourceType: .raw)
+        navigationViewportDataSource.options.followingCameraOptions.zoomUpdatesAllowed = false
+        navigationViewportDataSource.followingMobileCamera.zoom = 12.0
+        navigationMapView.navigationCamera.viewportDataSource = navigationViewportDataSource
+        
         view.addSubview(navigationMapView)
     }
+    @objc func tappedStartButton(_ button: UIButton) {
+        guard let route = currentRoute, let navigationRouteOptions = navigationRouteOptions else { return }
+        // For demonstration purposes, simulate locations if the Simulate Navigation option is on.
+        let navigationService = MapboxNavigationService(route: route,
+                                                        routeIndex: 0,
+                                                        routeOptions: navigationRouteOptions,
+                                                        simulating: simulationIsEnabled ? .always : .onPoorGPS)
+        let navigationOptions = NavigationOptions(navigationService: navigationService)
+        let navigationViewController = NavigationViewController(for: route, routeIndex: 0,
+                                                                routeOptions: navigationRouteOptions,
+                                                                navigationOptions: navigationOptions)
+        navigationViewController.delegate = self
+        
+        present(navigationViewController, animated: true, completion: nil)
+    }
+    
+    @objc func handleLongPress(_ gesture: UILongPressGestureRecognizer) {
+        guard gesture.state == .ended else { return }
+        let location = navigationMapView.mapView.mapboxMap.coordinate(for: gesture.location(in: navigationMapView.mapView))
+        
+        requestRoute(destination: location)
+    }
+    
+    func requestRoute(destination: CLLocationCoordinate2D) {
+        guard let userLocation = navigationMapView.mapView.location.latestLocation else { return }
+        let userWaypoint = Waypoint(location: userLocation.internalLocation, heading: userLocation.heading, name: "user")
+        let destinationWaypoint = Waypoint(coordinate: destination)
+        let navigationRouteOptions = NavigationRouteOptions(waypoints: [userWaypoint, destinationWaypoint])
+        
+        Directions.shared.calculate(navigationRouteOptions) { [weak self] (session, result) in
+            switch result {
+            case .failure(let error):
+                print(error.localizedDescription)
+            case .success(let response):
+                guard let routes = response.routes,
+                      let currentRoute = routes.first,
+                      let self = self else { return }
+                
+                self.navigationRouteOptions = navigationRouteOptions
+                self.routes = routes
+                self.startButton?.isHidden = false
+                self.navigationMapView.show(routes)
+                self.navigationMapView.showWaypoints(on: currentRoute)
+            }
+        }
+    }
+    
     
 // MARK: Handle State Changes
     var state: State = .beforeExampleSelected {
@@ -228,16 +377,22 @@ class OfflineRegionsViewController: UIViewController {
             switch(oldValue, state) {
             case(_, .initial):
              print("Example started!")
-            case (.initial, .downloading):
+//            case (.initial, .downloading):
+//                // Add ability to cancel download
+//                print()
+//                stateButton.setTitle("Cancel Download", for: .normal)
+//            case (.downloading, .downloaded):
+//                // Be able to display NavigationMapView
+//                enableShowNavigationMapView()
+            case (.initial, .downloaded):
                 // Add ability to cancel download
-                stateButton.setTitle("Cancel Download", for: .normal)
-            case (.downloading, .downloaded):
-                // Be able to display NavigationMapView
+                print()
                 enableShowNavigationMapView()
             case (.downloaded, .showingNavigationMapView):
                 showNavigationMapView()
             case (.showingNavigationMapView, .finished):
-                stateButton.setTitle("Reset", for: .normal)
+                print()
+//                stateButton.setTitle("Reset", for: .normal)
             default:
                 fatalError("Invalid transition from \(oldValue) to \(state).")
             }
@@ -249,10 +404,13 @@ class OfflineRegionsViewController: UIViewController {
         case .beforeExampleSelected:
             state = .initial
         case .initial:
+            print("!!! INITIAL STATE")
             downloadOfflineRegions()
-        case .downloading:
-            cancelDownloads()
+//        case .downloading:
+//            cancelDownloads()
+//            state = .downloaded
         case .downloaded:
+            print("!!! DOWNLOADED STATE")
             state = .showingNavigationMapView
         case .showingNavigationMapView:
             showDownloadedRegions()


### PR DESCRIPTION
Add offline regions example #96. Example covers the following functionality:

- Creating a custom TileStore
- Downloading a region (could have several hard-coded offline regions to download)
- Listing downloaded regions
- Refreshing outdated region
- Removing a region