### PR TITLE
Update to MapboxNavigation v2.0.0-beta.13

### DIFF
--- a/DocsCode/NavigationTutorial/NavigationTutorialViewController.swift
+++ b/DocsCode/NavigationTutorial/NavigationTutorialViewController.swift
@@ -29,7 +29,7 @@ class ViewController: UIViewController {
         navigationMapView.navigationCamera.viewportDataSource = navigationViewportDataSource
         
         // Allow the map to display the user's location
-        navigationMapView.mapView.location.options.puckType = .puck2D()
+        navigationMapView.userLocationStyle = .puck2D()
         
         // Add a gesture recognizer to the map view
         let longPress = UILongPressGestureRecognizer(target: self, action: #selector(didLongPress(_:)))

--- a/Navigation-Examples/Examples/Advanced.swift
+++ b/Navigation-Examples/Examples/Advanced.swift
@@ -41,7 +41,7 @@ class AdvancedViewController: UIViewController, NavigationMapViewDelegate, Navig
         navigationMapView = NavigationMapView(frame: view.bounds)
         navigationMapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         navigationMapView.delegate = self
-        navigationMapView.mapView.location.options.puckType = .puck2D()
+        navigationMapView.userLocationStyle = .puck2D()
         
         let navigationViewportDataSource = NavigationViewportDataSource(navigationMapView.mapView, viewportDataSourceType: .raw)
         navigationViewportDataSource.options.followingCameraOptions.zoomUpdatesAllowed = false

--- a/Navigation-Examples/Examples/Building-Extrusion.swift
+++ b/Navigation-Examples/Examples/Building-Extrusion.swift
@@ -52,7 +52,7 @@ class BuildingExtrusionViewController: UIViewController, NavigationMapViewDelega
         navigationMapView = NavigationMapView(frame: view.bounds)
         navigationMapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         navigationMapView.delegate = self
-        navigationMapView.mapView.location.options.puckType = .puck2D()
+        navigationMapView.userLocationStyle = .puck2D()
         
         // To make sure that buildings are rendered increase zoomLevel to value which is higher than 16.0.
         // More details can be found here: https://docs.mapbox.com/vector-tiles/reference/mapbox-streets-v8/#building

--- a/Navigation-Examples/Examples/Custom-Destination-Marker.swift
+++ b/Navigation-Examples/Examples/Custom-Destination-Marker.swift
@@ -11,6 +11,7 @@ class CustomDestinationMarkerController: UIViewController {
     var navigationRouteOptions: NavigationRouteOptions!
     var startNavigationButton: UIButton!
     var routes: [Route] = []
+    var pointAnnotationManager: PointAnnotationManager?
     
     // MARK: - UIViewController lifecycle methods
     
@@ -36,7 +37,12 @@ class CustomDestinationMarkerController: UIViewController {
         navigationMapView = NavigationMapView(frame: view.bounds)
         navigationMapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         navigationMapView.delegate = self
-        navigationMapView.mapView.location.options.puckType = .puck2D()
+        navigationMapView.userLocationStyle = .puck2D()
+        
+        navigationMapView.mapView.mapboxMap.onNext(.styleLoaded) { [weak self] _ in
+            guard let self = self else { return }
+            self.pointAnnotationManager = self.navigationMapView.mapView.annotations.makePointAnnotationManager()
+        }
         
         view.addSubview(navigationMapView)
     }
@@ -80,7 +86,7 @@ class CustomDestinationMarkerController: UIViewController {
         let destination = CLLocationCoordinate2DMake(37.76556957793795, -122.42409811526268)
         let navigationRouteOptions = NavigationRouteOptions(coordinates: [origin, destination])
         
-        navigationMapView.mapView.camera.setCamera(to: CameraOptions(center: destination, zoom: 13.0))
+        navigationMapView.mapView.mapboxMap.setCamera(to: CameraOptions(center: destination, zoom: 13.0))
         
         Directions.shared.calculate(navigationRouteOptions) { [weak self] (session, result) in
             switch result {
@@ -108,13 +114,13 @@ extension CustomDestinationMarkerController: NavigationMapViewDelegate {
     
     func navigationMapView(_ navigationMapView: NavigationMapView, didAdd finalDestinationAnnotation: PointAnnotation) {
         var finalDestinationAnnotation = finalDestinationAnnotation
-        finalDestinationAnnotation.image = UIImage(named: "marker")
-        
-        do {
-            try navigationMapView.mapView.annotations.updateAnnotation(finalDestinationAnnotation)
-        } catch {
-            NSLog("Error occured: \(error.localizedDescription).")
+        if let image = UIImage(named: "marker") {
+            finalDestinationAnnotation.image = PointAnnotation.Image.custom(image: image, name: "marker")
+        } else {
+            finalDestinationAnnotation.image = .default
         }
+        
+        pointAnnotationManager?.syncAnnotations([finalDestinationAnnotation])
     }
 }
 
@@ -124,13 +130,13 @@ extension CustomDestinationMarkerController: NavigationViewControllerDelegate {
     
     func navigationViewController(_ navigationViewController: NavigationViewController, didAdd finalDestinationAnnotation: PointAnnotation) {
         var finalDestinationAnnotation = finalDestinationAnnotation
-        finalDestinationAnnotation.image = UIImage(named: "marker")
-        
-        do {
-            try navigationViewController.navigationMapView?.mapView.annotations.updateAnnotation(finalDestinationAnnotation)
-        } catch {
-            NSLog("Error occured: \(error.localizedDescription).")
+        if let image = UIImage(named: "marker") {
+            finalDestinationAnnotation.image = PointAnnotation.Image.custom(image: image, name: "marker")
+        } else {
+            finalDestinationAnnotation.image = .default
         }
+        
+        pointAnnotationManager?.syncAnnotations([finalDestinationAnnotation])
     }
     
     func navigationViewControllerDidDismiss(_ navigationViewController: NavigationViewController, byCanceling canceled: Bool) {

--- a/Navigation-Examples/Examples/Custom-Waypoints.swift
+++ b/Navigation-Examples/Examples/Custom-Waypoints.swift
@@ -31,7 +31,7 @@ class CustomWaypointsViewController: UIViewController {
         navigationMapView = NavigationMapView(frame: view.bounds)
         navigationMapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         navigationMapView.delegate = self
-        navigationMapView.mapView.location.options.puckType = .puck2D()
+        navigationMapView.userLocationStyle = .puck2D()
         
         view.addSubview(navigationMapView)
         
@@ -83,7 +83,7 @@ class CustomWaypointsViewController: UIViewController {
         let navigationRouteOptions = NavigationRouteOptions(coordinates: [origin, firstWaypoint, secondWaypoint])
         
         let cameraOptions = CameraOptions(center: origin, zoom: 13.0)
-        self.navigationMapView.mapView.camera.setCamera(to: cameraOptions)
+        self.navigationMapView.mapView.mapboxMap.setCamera(to: cameraOptions)
         
         Directions.shared.calculate(navigationRouteOptions) { [weak self] (session, result) in
             switch result {
@@ -153,7 +153,7 @@ class CustomWaypointsViewController: UIViewController {
     }
 
     func customWaypointShape(shapeFor waypoints: [Waypoint], legIndex: Int) -> FeatureCollection {
-        var features = [Feature]()
+        var features = [Turf.Feature]()
         for (waypointIndex, waypoint) in waypoints.enumerated() {
             var feature = Feature(Point(waypoint.coordinate))
             feature.properties = [

--- a/Navigation-Examples/Examples/Location-Snapping.swift
+++ b/Navigation-Examples/Examples/Location-Snapping.swift
@@ -26,7 +26,7 @@ class LocationSnappingViewController: UIViewController {
     
     private func setupNavigationMapView() {
         navigationMapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-        navigationMapView.mapView.location.options.puckType = .puck2D()
+        navigationMapView.userLocationStyle = .puck2D()
         
         let navigationViewportDataSource = NavigationViewportDataSource(navigationMapView.mapView)
         navigationViewportDataSource.options.followingCameraOptions.zoomUpdatesAllowed = false

--- a/Navigation-Examples/Examples/NavigationCamera/Custom-Navigation-Camera.swift
+++ b/Navigation-Examples/Examples/NavigationCamera/Custom-Navigation-Camera.swift
@@ -33,7 +33,7 @@ class CustomNavigationCameraViewController: UIViewController {
     func setupNavigationMapView() {
         navigationMapView = NavigationMapView(frame: view.bounds)
         navigationMapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-        navigationMapView.mapView.location.options.puckType = .puck2D()
+        navigationMapView.userLocationStyle = .puck2D()
         
         // Modify default `NavigationViewportDataSource` and `NavigationCameraStateTransition` to change
         // `NavigationCamera` behavior during free drive and when locations are provided by Maps SDK directly.

--- a/Navigation-Examples/Examples/Route-Lines-Styling.swift
+++ b/Navigation-Examples/Examples/Route-Lines-Styling.swift
@@ -51,7 +51,7 @@ class RouteLinesStylingViewController: UIViewController {
         navigationMapView = NavigationMapView(frame: view.bounds)
         navigationMapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         navigationMapView.delegate = self
-        navigationMapView.mapView.location.options.puckType = .puck2D()
+        navigationMapView.userLocationStyle = .puck2D()
         
         let navigationViewportDataSource = NavigationViewportDataSource(navigationMapView.mapView, viewportDataSourceType: .raw)
         navigationMapView.navigationCamera.viewportDataSource = navigationViewportDataSource

--- a/Navigation-Examples/Examples/Upcoming-Intersection.swift
+++ b/Navigation-Examples/Examples/Upcoming-Intersection.swift
@@ -22,7 +22,7 @@ class ObservingElectronicHorizonEventsViewController: UIViewController {
     func setupNavigationMapView() {
         navigationMapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         navigationMapView.mapView.location.overrideLocationProvider(with: passiveLocationManager)
-        navigationMapView.mapView.location.options.puckType = .puck2D()
+        navigationMapView.userLocationStyle = .puck2D()
         navigationMapView.mapView.mapboxMap.onNext(.styleLoaded, handler: { [weak self] _ in
             self?.setupMostProbablePathStyle()
         })

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,29 +1,29 @@
 PODS:
-  - MapboxCommon (12.0.0)
-  - MapboxCoreMaps (10.0.0-beta.22):
-    - MapboxCommon (~> 12.0.0)
-  - MapboxCoreNavigation (2.0.0-beta.12):
+  - MapboxCommon (13.0.0)
+  - MapboxCoreMaps (10.0.0-beta.23):
+    - MapboxCommon (~> 13.0.0)
+  - MapboxCoreNavigation (2.0.0-beta.13):
     - MapboxDirections-pre (= 2.0.0-beta.3)
-    - MapboxMobileEvents (~> 0.10.2)
-    - MapboxNavigationNative (~> 50.0)
+    - MapboxMobileEvents (~> 1.0.0)
+    - MapboxNavigationNative (~> 52.0)
     - Turf (= 2.0.0-alpha.3)
   - MapboxDirections-pre (2.0.0-beta.3):
     - Polyline (~> 5.0)
     - Turf (~> 2.0.0-alpha.3)
-  - MapboxMaps (10.0.0-beta.20):
-    - MapboxCommon (~> 12.0.0)
-    - MapboxCoreMaps (= 10.0.0-beta.22)
-    - MapboxMobileEvents (= 0.10.8)
+  - MapboxMaps (10.0.0-beta.21):
+    - MapboxCommon (~> 13.0.0)
+    - MapboxCoreMaps (= 10.0.0-beta.23)
+    - MapboxMobileEvents (= 1.0.0)
     - Turf (= 2.0.0-alpha.3)
-  - MapboxMobileEvents (0.10.8)
-  - MapboxNavigation (2.0.0-beta.12):
-    - MapboxCoreNavigation (= 2.0.0-beta.12)
-    - MapboxMaps (= 10.0.0-beta.20)
-    - MapboxMobileEvents (~> 0.10.2)
+  - MapboxMobileEvents (1.0.0)
+  - MapboxNavigation (2.0.0-beta.13):
+    - MapboxCoreNavigation (= 2.0.0-beta.13)
+    - MapboxMaps (= 10.0.0-beta.21)
+    - MapboxMobileEvents (~> 1.0.0)
     - MapboxSpeech-pre (= 2.0.0-alpha.1)
     - Solar (~> 2.1)
-  - MapboxNavigationNative (50.0.0):
-    - MapboxCommon (~> 12.0)
+  - MapboxNavigationNative (52.0.0):
+    - MapboxCommon (~> 13.0)
   - MapboxSpeech-pre (2.0.0-alpha.1)
   - Polyline (5.0.2)
   - Solar (2.1.0)
@@ -56,21 +56,21 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   MapboxCoreNavigation:
-    :commit: 48c312c3fd2830a08b2079a58db535dfcaa8508e
+    :commit: d506eed913134899547ff849cbe9a9578658d704
     :git: https://github.com/mapbox/mapbox-navigation-ios.git
   MapboxNavigation:
-    :commit: 48c312c3fd2830a08b2079a58db535dfcaa8508e
+    :commit: d506eed913134899547ff849cbe9a9578658d704
     :git: https://github.com/mapbox/mapbox-navigation-ios.git
 
 SPEC CHECKSUMS:
-  MapboxCommon: 5d38df5a519c1c5419dca4751c20516b99b5bb27
-  MapboxCoreMaps: 73965fb516164df3e66f5c2b98e6a2239c0db1ac
-  MapboxCoreNavigation: 43ab98e65ce68656ee05e4b4cd6312b6ba6991f1
+  MapboxCommon: 8fafaddbeafe9801d9bfdeac24380df9da195277
+  MapboxCoreMaps: 1c68457fc2393293fdd56c2315acb673db7f2af1
+  MapboxCoreNavigation: eff0cb77d3021c7b5cd872f7c15a0c30c3bfa5a5
   MapboxDirections-pre: 221ad1f4ee428346923654f55898c5a7c6e79ecb
-  MapboxMaps: 3dd2f97f3e600bc6c599a29306fa5047200b9fa0
-  MapboxMobileEvents: 36ff53b135aac486eed94b61f813c7967a0c2c6f
-  MapboxNavigation: 41a6207b086088330eb72a848fc0449a551829be
-  MapboxNavigationNative: 94ea4cb642461495178fa1794adcf6cbccdd5a4e
+  MapboxMaps: 3423025d12624d030a8ac19dd099875781c8b81d
+  MapboxMobileEvents: 6e8f4b7c86e2fbc5a01605fd2c5e720ad5434ff6
+  MapboxNavigation: 85d9ce7aea92cb1c997d0796c433549115190356
+  MapboxNavigationNative: 063d7c29530525914a2ccf6ff0009926eb03e6e7
   MapboxSpeech-pre: aeb16de604d07ceb4195150c3359d5401bb298e6
   Polyline: fce41d72e1146c41c6d081f7656827226f643dff
   Solar: 2dc6e7cc39186cb0c8228fa08df76fb50c7d8f24


### PR DESCRIPTION
This pr is to keep the examples update to date with the  v2.0.0-beta.13 release of `MapboxNavigation`. 