### PR TITLE
Update to MapboxNavigation v2.0.0-beta.19

### DIFF
--- a/Navigation-Examples.xcodeproj/project.pbxproj
+++ b/Navigation-Examples.xcodeproj/project.pbxproj
@@ -53,14 +53,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		01D167067A6027DCA4D44BF3 /* Pods-Navigation-Examples-DocsCode.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Navigation-Examples-DocsCode.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Navigation-Examples-DocsCode/Pods-Navigation-Examples-DocsCode.debug.xcconfig"; sourceTree = "<group>"; };
 		020D595E7751FB434720AACD /* Pods_Navigation_Examples.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Navigation_Examples.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		11B6E81626176F3600872E4D /* Upcoming-Intersection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Upcoming-Intersection.swift"; sourceTree = "<group>"; };
 		11DC36F126161DAF0042CD4A /* Location-Snapping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Location-Snapping.swift"; sourceTree = "<group>"; };
-		1E6EDEBB177F0E6643EC4DB9 /* Pods-Navigation-Examples-DocsCode.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Navigation-Examples-DocsCode.release.xcconfig"; path = "Pods/Target Support Files/Pods-Navigation-Examples-DocsCode/Pods-Navigation-Examples-DocsCode.release.xcconfig"; sourceTree = "<group>"; };
 		2B521D4D24090A3A00984CF8 /* CustomBarsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomBarsViewController.swift; sourceTree = "<group>"; };
 		2B521D4F2409240E00984CF8 /* CustomBottomBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomBottomBannerView.swift; sourceTree = "<group>"; };
 		2B521D512409242A00984CF8 /* CustomBottomBannerView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CustomBottomBannerView.xib; sourceTree = "<group>"; };
+		4EF74F60792B221A1A61A3CE /* Pods-Navigation-Examples.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Navigation-Examples.debug.xcconfig"; path = "Target Support Files/Pods-Navigation-Examples/Pods-Navigation-Examples.debug.xcconfig"; sourceTree = "<group>"; };
 		8A0B182226553482005107DE /* CustomSegue.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = CustomSegue.storyboard; sourceTree = "<group>"; };
 		8A2DFA55261650A60034A87E /* CustomCameraStateTransition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomCameraStateTransition.swift; sourceTree = "<group>"; };
 		8A2DFA56261650A60034A87E /* CustomViewportDataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomViewportDataSource.swift; sourceTree = "<group>"; };
@@ -75,6 +74,7 @@
 		8D6D36A620001F0400C2B61B /* EmbeddedExamples.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = EmbeddedExamples.storyboard; sourceTree = "<group>"; };
 		8DF510731FEB08F70049DB9C /* Embedded-Navigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Embedded-Navigation.swift"; sourceTree = "<group>"; };
 		8DF510761FEB0CA00049DB9C /* MapboxNavigation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = MapboxNavigation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		9223D8DB7C82389A1E85E3E5 /* Pods-DocsCode.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DocsCode.debug.xcconfig"; path = "Target Support Files/Pods-DocsCode/Pods-DocsCode.debug.xcconfig"; sourceTree = "<group>"; };
 		9613F58622E030AC00D34E24 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		9613F58722E030AC00D34E24 /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
 		961FC4E722E0260A00C72877 /* DocsCode-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "DocsCode-Bridging-Header.h"; sourceTree = "<group>"; };
@@ -83,14 +83,12 @@
 		961FC4F122E0260A00C72877 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		961FC4F222E0260A00C72877 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		961FC4FE22E0265300C72877 /* DocsCode.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DocsCode.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		9A4F31D3A4350E716451A486 /* Pods-DocsCode.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DocsCode.debug.xcconfig"; path = "Pods/Target Support Files/Pods-DocsCode/Pods-DocsCode.debug.xcconfig"; sourceTree = "<group>"; };
 		9B796D93B6E7934BFD326FA8 /* Pods_DocsCode.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_DocsCode.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		B33B5E4C0AD283368D51EEDA /* Pods-DocsCode.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DocsCode.release.xcconfig"; path = "Pods/Target Support Files/Pods-DocsCode/Pods-DocsCode.release.xcconfig"; sourceTree = "<group>"; };
+		A8BC0BE26AF9683D3B034741 /* Pods-Navigation-Examples.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Navigation-Examples.release.xcconfig"; path = "Target Support Files/Pods-Navigation-Examples/Pods-Navigation-Examples.release.xcconfig"; sourceTree = "<group>"; };
 		B4747F57268CE9C800BE884B /* MSL_clean.gltf */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = MSL_clean.gltf; sourceTree = "<group>"; };
 		B480E423261E4C3500C16FA0 /* Predictive-Caching.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Predictive-Caching.swift"; sourceTree = "<group>"; };
 		B480E427261E4C4600C16FA0 /* Route-Alerts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Route-Alerts.swift"; sourceTree = "<group>"; };
 		B4F805ED26791AD900D5F1C8 /* Custom-User-Location.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Custom-User-Location.swift"; sourceTree = "<group>"; };
-		BFEC70FB9C884A4DDD80E7D9 /* Pods-Navigation-Examples.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Navigation-Examples.release.xcconfig"; path = "Pods/Target Support Files/Pods-Navigation-Examples/Pods-Navigation-Examples.release.xcconfig"; sourceTree = "<group>"; };
 		C3893F1B25F96BDC0058A987 /* Custom-Waypoints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Custom-Waypoints.swift"; sourceTree = "<group>"; };
 		C52BAA772040D5030086EC6B /* Custom-Destination-Marker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Custom-Destination-Marker.swift"; sourceTree = "<group>"; };
 		C58FB8561FE899B800C4B491 /* Navigation-Examples.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Navigation-Examples.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -108,7 +106,7 @@
 		C5C0D63720589422003A3B1D /* Custom-Server.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Custom-Server.swift"; sourceTree = "<group>"; };
 		C5F1309F1FE9B44600463E86 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		C5F130A51FEB2D7800463E86 /* Advanced.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Advanced.swift; sourceTree = "<group>"; };
-		FE9EEF42C4F1DD67E96BC63A /* Pods-Navigation-Examples.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Navigation-Examples.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Navigation-Examples/Pods-Navigation-Examples.debug.xcconfig"; sourceTree = "<group>"; };
+		FAC970C66A93305A51421FFF /* Pods-DocsCode.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DocsCode.release.xcconfig"; path = "Target Support Files/Pods-DocsCode/Pods-DocsCode.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -132,19 +130,6 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		1DB15F41255AE89621E98535 /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				FE9EEF42C4F1DD67E96BC63A /* Pods-Navigation-Examples.debug.xcconfig */,
-				BFEC70FB9C884A4DDD80E7D9 /* Pods-Navigation-Examples.release.xcconfig */,
-				9A4F31D3A4350E716451A486 /* Pods-DocsCode.debug.xcconfig */,
-				B33B5E4C0AD283368D51EEDA /* Pods-DocsCode.release.xcconfig */,
-				01D167067A6027DCA4D44BF3 /* Pods-Navigation-Examples-DocsCode.debug.xcconfig */,
-				1E6EDEBB177F0E6643EC4DB9 /* Pods-Navigation-Examples-DocsCode.release.xcconfig */,
-			);
-			name = Pods;
-			sourceTree = "<group>";
-		};
 		2B521D5324094F2500984CF8 /* CustomBars */ = {
 			isa = PBXGroup;
 			children = (
@@ -220,8 +205,8 @@
 				961FC4E622E0260A00C72877 /* DocsCode */,
 				8A5BBF6A2489B0A000FA4960 /* Scripts */,
 				C58FB8571FE899B800C4B491 /* Products */,
-				1DB15F41255AE89621E98535 /* Pods */,
 				DE25A5BE57093A8DAF382733 /* Frameworks */,
+				CD6C5E143037B23CC030FBDD /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -278,6 +263,18 @@
 				2B521D5324094F2500984CF8 /* CustomBars */,
 			);
 			path = Examples;
+			sourceTree = "<group>";
+		};
+		CD6C5E143037B23CC030FBDD /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				9223D8DB7C82389A1E85E3E5 /* Pods-DocsCode.debug.xcconfig */,
+				FAC970C66A93305A51421FFF /* Pods-DocsCode.release.xcconfig */,
+				4EF74F60792B221A1A61A3CE /* Pods-Navigation-Examples.debug.xcconfig */,
+				A8BC0BE26AF9683D3B034741 /* Pods-Navigation-Examples.release.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
 			sourceTree = "<group>";
 		};
 		DE25A5BE57093A8DAF382733 /* Frameworks */ = {
@@ -449,7 +446,6 @@
 				"${PODS_ROOT}/Target Support Files/Pods-Navigation-Examples/Pods-Navigation-Examples-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/MapboxCoreNavigation/MapboxCoreNavigation.framework",
 				"${BUILT_PRODUCTS_DIR}/MapboxDirections-pre/MapboxDirections.framework",
-				"${BUILT_PRODUCTS_DIR}/MapboxGeocoder.swift/MapboxGeocoder.framework",
 				"${BUILT_PRODUCTS_DIR}/MapboxMaps/MapboxMaps.framework",
 				"${BUILT_PRODUCTS_DIR}/MapboxNavigation/MapboxNavigation.framework",
 				"${BUILT_PRODUCTS_DIR}/MapboxSpeech-pre/MapboxSpeech.framework",
@@ -465,7 +461,6 @@
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MapboxCoreNavigation.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MapboxDirections.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MapboxGeocoder.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MapboxMaps.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MapboxNavigation.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MapboxSpeech.framework",
@@ -565,7 +560,6 @@
 				"${PODS_ROOT}/Target Support Files/Pods-DocsCode/Pods-DocsCode-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/MapboxCoreNavigation/MapboxCoreNavigation.framework",
 				"${BUILT_PRODUCTS_DIR}/MapboxDirections-pre/MapboxDirections.framework",
-				"${BUILT_PRODUCTS_DIR}/MapboxGeocoder.swift/MapboxGeocoder.framework",
 				"${BUILT_PRODUCTS_DIR}/MapboxMaps/MapboxMaps.framework",
 				"${BUILT_PRODUCTS_DIR}/MapboxNavigation/MapboxNavigation.framework",
 				"${BUILT_PRODUCTS_DIR}/MapboxSpeech-pre/MapboxSpeech.framework",
@@ -581,7 +575,6 @@
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MapboxCoreNavigation.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MapboxDirections.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MapboxGeocoder.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MapboxMaps.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MapboxNavigation.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MapboxSpeech.framework",
@@ -669,7 +662,7 @@
 /* Begin XCBuildConfiguration section */
 		961FC51222E0265400C72877 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 9A4F31D3A4350E716451A486 /* Pods-DocsCode.debug.xcconfig */;
+			baseConfigurationReference = 9223D8DB7C82389A1E85E3E5 /* Pods-DocsCode.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_OBJC_WEAK = YES;
@@ -688,7 +681,7 @@
 		};
 		961FC51322E0265400C72877 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = B33B5E4C0AD283368D51EEDA /* Pods-DocsCode.release.xcconfig */;
+			baseConfigurationReference = FAC970C66A93305A51421FFF /* Pods-DocsCode.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_OBJC_WEAK = YES;
@@ -819,7 +812,7 @@
 		};
 		C58FB8691FE899B800C4B491 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = FE9EEF42C4F1DD67E96BC63A /* Pods-Navigation-Examples.debug.xcconfig */;
+			baseConfigurationReference = 4EF74F60792B221A1A61A3CE /* Pods-Navigation-Examples.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
@@ -835,7 +828,7 @@
 		};
 		C58FB86A1FE899B800C4B491 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = BFEC70FB9C884A4DDD80E7D9 /* Pods-Navigation-Examples.release.xcconfig */;
+			baseConfigurationReference = A8BC0BE26AF9683D3B034741 /* Pods-Navigation-Examples.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;

--- a/Navigation-Examples/Examples/Custom-Server.swift
+++ b/Navigation-Examples/Examples/Custom-Server.swift
@@ -80,8 +80,11 @@ extension CustomServerViewController: NavigationViewControllerDelegate {
                             return
                         }
                         
+                        // Convert matchOptions to `RouteOptions`
+                        let routeOptions = RouteOptions(matchOptions: matchOptions)
+                        
                         // Set the route
-                        self?.navigationViewController?.navigationService.indexedRoute = (route, 0)
+                        self?.navigationViewController?.navigationService.router.updateRoute(with: (route, 0), routeOptions: routeOptions)
                     }
                 }
             }

--- a/Navigation-Examples/Examples/Embedded-Navigation.swift
+++ b/Navigation-Examples/Examples/Embedded-Navigation.swift
@@ -17,10 +17,6 @@ class EmbeddedExampleViewController: UIViewController {
         return NavigationRouteOptions(coordinates: [origin, destination])
     }()
     
-    deinit {
-        NotificationCenter.default.removeObserver(self)
-    }
-    
     override func viewDidLoad() {
         super.viewDidLoad()
         

--- a/Podfile
+++ b/Podfile
@@ -1,8 +1,8 @@
 platform :ios, '11.0'
 use_frameworks!
 
-pod 'MapboxCoreNavigation', :git => 'https://github.com/mapbox/mapbox-navigation-ios.git', :tag => 'v2.0.0-beta.18'
-pod 'MapboxNavigation', :git => 'https://github.com/mapbox/mapbox-navigation-ios.git', :tag => 'v2.0.0-beta.18'
+pod 'MapboxCoreNavigation', :git => 'https://github.com/mapbox/mapbox-navigation-ios.git', :tag => 'v2.0.0-beta.19'
+pod 'MapboxNavigation', :git => 'https://github.com/mapbox/mapbox-navigation-ios.git', :tag => 'v2.0.0-beta.19'
 
 target 'Navigation-Examples' do
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -2,7 +2,7 @@ PODS:
   - MapboxCommon (14.2.0)
   - MapboxCoreMaps (10.0.0-rc.3):
     - MapboxCommon (~> 14.2.0)
-  - MapboxCoreNavigation (2.0.0-beta.18):
+  - MapboxCoreNavigation (2.0.0-beta.19):
     - MapboxDirections-pre (= 2.0.0-beta.6)
     - MapboxMobileEvents (~> 1.0.0)
     - MapboxNavigationNative (~> 56.0)
@@ -10,16 +10,14 @@ PODS:
   - MapboxDirections-pre (2.0.0-beta.6):
     - Polyline (~> 5.0)
     - Turf (~> 2.0.0-beta.1)
-  - MapboxGeocoder.swift (0.10.2)
   - MapboxMaps (10.0.0-rc.3):
     - MapboxCommon (= 14.2.0)
     - MapboxCoreMaps (= 10.0.0-rc.3)
     - MapboxMobileEvents (= 1.0.2)
     - Turf (= 2.0.0-beta.1)
   - MapboxMobileEvents (1.0.2)
-  - MapboxNavigation (2.0.0-beta.18):
-    - MapboxCoreNavigation (= 2.0.0-beta.18)
-    - MapboxGeocoder.swift (~> 0.10.0)
+  - MapboxNavigation (2.0.0-beta.19):
+    - MapboxCoreNavigation (= 2.0.0-beta.19)
     - MapboxMaps (= 10.0.0-rc.3)
     - MapboxMobileEvents (~> 1.0.0)
     - MapboxSpeech-pre (= 2.0.0-alpha.1)
@@ -32,15 +30,14 @@ PODS:
   - Turf (2.0.0-beta.1)
 
 DEPENDENCIES:
-  - MapboxCoreNavigation (from `https://github.com/mapbox/mapbox-navigation-ios.git`, tag `v2.0.0-beta.18`)
-  - MapboxNavigation (from `https://github.com/mapbox/mapbox-navigation-ios.git`, tag `v2.0.0-beta.18`)
+  - MapboxCoreNavigation (from `https://github.com/mapbox/mapbox-navigation-ios.git`, tag `v2.0.0-beta.19`)
+  - MapboxNavigation (from `https://github.com/mapbox/mapbox-navigation-ios.git`, tag `v2.0.0-beta.19`)
 
 SPEC REPOS:
   trunk:
     - MapboxCommon
     - MapboxCoreMaps
     - MapboxDirections-pre
-    - MapboxGeocoder.swift
     - MapboxMaps
     - MapboxMobileEvents
     - MapboxNavigationNative
@@ -52,34 +49,33 @@ SPEC REPOS:
 EXTERNAL SOURCES:
   MapboxCoreNavigation:
     :git: https://github.com/mapbox/mapbox-navigation-ios.git
-    :tag: v2.0.0-beta.18
+    :tag: v2.0.0-beta.19
   MapboxNavigation:
     :git: https://github.com/mapbox/mapbox-navigation-ios.git
-    :tag: v2.0.0-beta.18
+    :tag: v2.0.0-beta.19
 
 CHECKOUT OPTIONS:
   MapboxCoreNavigation:
     :git: https://github.com/mapbox/mapbox-navigation-ios.git
-    :tag: v2.0.0-beta.18
+    :tag: v2.0.0-beta.19
   MapboxNavigation:
     :git: https://github.com/mapbox/mapbox-navigation-ios.git
-    :tag: v2.0.0-beta.18
+    :tag: v2.0.0-beta.19
 
 SPEC CHECKSUMS:
   MapboxCommon: dc7a183d1b8a796b87caa92a6d331ea0efa683a2
   MapboxCoreMaps: f22db9897af647866089323632f3309e3f7a6a38
-  MapboxCoreNavigation: 33eb8424b75e33927dbd6f94fe9e9871357a5a33
+  MapboxCoreNavigation: 42714966ff28e7c5eedcf788419392c3372ee361
   MapboxDirections-pre: e1f574d531eb18e03b0b50fef32c471da4c8986f
-  MapboxGeocoder.swift: 8cff5dddf98d87838509bf80a5bce5f1d0cf8393
   MapboxMaps: 2192a4ae4aef6376febe0f2779905b58ea2e2a27
   MapboxMobileEvents: 9775eb995e06cc3ea10894bf6ab111683c8e73e7
-  MapboxNavigation: d65da30404dc0451450da8460cd9d6e1d53d4d09
+  MapboxNavigation: f71fc519c6aacd5fc51446a4403f99ef1ea61e5d
   MapboxNavigationNative: 1192307e39db93bebe28a298849beb55baf7ae74
   MapboxSpeech-pre: aeb16de604d07ceb4195150c3359d5401bb298e6
   Polyline: fce41d72e1146c41c6d081f7656827226f643dff
   Solar-dev: 4612dc9878b9fed2667d23b327f1d4e54e16e8d0
   Turf: 8851f941a6e6476ea200bf057d31cf21b2418467
 
-PODFILE CHECKSUM: 15efb232a5bf800deb8a9c9a1c3336969bbca732
+PODFILE CHECKSUM: e2072ca62140230ac2bb7cbbc33a2780d859fc57
 
 COCOAPODS: 1.10.1


### PR DESCRIPTION
* Updated examples to MapboxNavigation v2.0.0-beta.19
* Removed `deinit` from embedded navigation example due to SwiftLint-related error