### PR TITLE
Update NavSDK version to 2.0.0-beta.22

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,8 +1,8 @@
 platform :ios, '11.0'
 use_frameworks!
 
-pod 'MapboxCoreNavigation', :git => 'https://github.com/mapbox/mapbox-navigation-ios.git', :tag => 'v2.0.0-beta.21'
-pod 'MapboxNavigation', :git => 'https://github.com/mapbox/mapbox-navigation-ios.git', :tag => 'v2.0.0-beta.21'
+pod 'MapboxCoreNavigation', :git => 'https://github.com/mapbox/mapbox-navigation-ios.git', :tag => 'v2.0.0-beta.22'
+pod 'MapboxNavigation', :git => 'https://github.com/mapbox/mapbox-navigation-ios.git', :tag => 'v2.0.0-beta.22'
 
 target 'Navigation-Examples' do
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,37 +1,37 @@
 PODS:
-  - MapboxCommon (16.0.0)
-  - MapboxCoreMaps (10.0.0-rc.5):
-    - MapboxCommon (~> 16.0.0)
-  - MapboxCoreNavigation (2.0.0-beta.21):
-    - MapboxDirections-pre (= 2.0.0-beta.7)
+  - MapboxCommon (16.2.0)
+  - MapboxCoreMaps (10.0.0-rc.6):
+    - MapboxCommon (~> 16.2)
+  - MapboxCoreNavigation (2.0.0-beta.22):
+    - MapboxDirections-pre (= 2.0.0-beta.8)
     - MapboxMobileEvents (~> 1.0.0)
-    - MapboxNavigationNative (~> 60.0)
-    - Turf (= 2.0.0-beta.1)
-  - MapboxDirections-pre (2.0.0-beta.7):
+    - MapboxNavigationNative (~> 62.0)
+    - Turf (= 2.0.0-rc.1)
+  - MapboxDirections-pre (2.0.0-beta.8):
     - Polyline (~> 5.0)
-    - Turf (~> 2.0.0-beta.1)
-  - MapboxMaps (10.0.0-rc.5):
-    - MapboxCommon (= 16.0.0)
-    - MapboxCoreMaps (= 10.0.0-rc.5)
+    - Turf (~> 2.0.0-rc.1)
+  - MapboxMaps (10.0.0-rc.6):
+    - MapboxCommon (= 16.2.0)
+    - MapboxCoreMaps (= 10.0.0-rc.6)
     - MapboxMobileEvents (= 1.0.2)
-    - Turf (= 2.0.0-beta.1)
+    - Turf (= 2.0.0-rc.1)
   - MapboxMobileEvents (1.0.2)
-  - MapboxNavigation (2.0.0-beta.21):
-    - MapboxCoreNavigation (= 2.0.0-beta.21)
-    - MapboxMaps (= 10.0.0-rc.5)
+  - MapboxNavigation (2.0.0-beta.22):
+    - MapboxCoreNavigation (= 2.0.0-beta.22)
+    - MapboxMaps (= 10.0.0-rc.6)
     - MapboxMobileEvents (~> 1.0.0)
     - MapboxSpeech-pre (= 2.0.0-alpha.1)
     - Solar-dev (~> 3.0)
-  - MapboxNavigationNative (60.0.0):
-    - MapboxCommon (~> 16.0)
+  - MapboxNavigationNative (62.0.0):
+    - MapboxCommon (~> 16.2)
   - MapboxSpeech-pre (2.0.0-alpha.1)
   - Polyline (5.0.2)
   - Solar-dev (3.0.1)
-  - Turf (2.0.0-beta.1)
+  - Turf (2.0.0-rc.1)
 
 DEPENDENCIES:
-  - MapboxCoreNavigation (from `https://github.com/mapbox/mapbox-navigation-ios.git`, tag `v2.0.0-beta.21`)
-  - MapboxNavigation (from `https://github.com/mapbox/mapbox-navigation-ios.git`, tag `v2.0.0-beta.21`)
+  - MapboxCoreNavigation (from `https://github.com/mapbox/mapbox-navigation-ios.git`, tag `v2.0.0-beta.22`)
+  - MapboxNavigation (from `https://github.com/mapbox/mapbox-navigation-ios.git`, tag `v2.0.0-beta.22`)
 
 SPEC REPOS:
   trunk:
@@ -49,33 +49,33 @@ SPEC REPOS:
 EXTERNAL SOURCES:
   MapboxCoreNavigation:
     :git: https://github.com/mapbox/mapbox-navigation-ios.git
-    :tag: v2.0.0-beta.21
+    :tag: v2.0.0-beta.22
   MapboxNavigation:
     :git: https://github.com/mapbox/mapbox-navigation-ios.git
-    :tag: v2.0.0-beta.21
+    :tag: v2.0.0-beta.22
 
 CHECKOUT OPTIONS:
   MapboxCoreNavigation:
     :git: https://github.com/mapbox/mapbox-navigation-ios.git
-    :tag: v2.0.0-beta.21
+    :tag: v2.0.0-beta.22
   MapboxNavigation:
     :git: https://github.com/mapbox/mapbox-navigation-ios.git
-    :tag: v2.0.0-beta.21
+    :tag: v2.0.0-beta.22
 
 SPEC CHECKSUMS:
-  MapboxCommon: 44430838b703d0b1b5032f3c8501c60c7c70d3cc
-  MapboxCoreMaps: 0aa69120a787fce64eb66ea1068a707fbc0a3c8b
-  MapboxCoreNavigation: d79eb0b5d0d35c9ebaadbc7ed9bc07faff58c0e4
-  MapboxDirections-pre: 929a1a63063c9c97f88b793e70143d547eaed293
-  MapboxMaps: b966939712943f6af126aadf73b82b43c0535020
+  MapboxCommon: 4fd3d1f439655efbe0108ecd45406924054071aa
+  MapboxCoreMaps: 045ecad9bb77931e221edc122a66848d778ea87c
+  MapboxCoreNavigation: 9e36092a119a6908582f5c0597af4a8e04e36411
+  MapboxDirections-pre: ac837a27e6f023ea9abcc00dff53d17b080023d2
+  MapboxMaps: de9ac5e180c0a5957619a8642b96767108d2f9b4
   MapboxMobileEvents: 9775eb995e06cc3ea10894bf6ab111683c8e73e7
-  MapboxNavigation: 4cd5a5c46c9ec186f46b9509f85e5fe0c8782221
-  MapboxNavigationNative: 9f49640451eca820667c657475d412e1c990d41b
+  MapboxNavigation: 02d5942d2964a79aec17a251a7e9f688d27ee510
+  MapboxNavigationNative: 1c91a4ca1a963a17299640a89d88ce1a97a77f09
   MapboxSpeech-pre: aeb16de604d07ceb4195150c3359d5401bb298e6
   Polyline: fce41d72e1146c41c6d081f7656827226f643dff
   Solar-dev: 4612dc9878b9fed2667d23b327f1d4e54e16e8d0
-  Turf: 8851f941a6e6476ea200bf057d31cf21b2418467
+  Turf: 4efd14674a1a2f9527b7c0aadde8003a7b73b1be
 
-PODFILE CHECKSUM: 4bfa0e9eec36e25c79d28b92d9eb25b0a29594e8
+PODFILE CHECKSUM: da77984ec3a1c4d9bc9c2a67176f11f09cb25782
 
-COCOAPODS: 1.10.1
+COCOAPODS: 1.10.2


### PR DESCRIPTION
Updating examples to the latest beta version of Navigation SDK.