### PR TITLE
Use `showcase(_:animated:)` method to display route and destination for tutorial

### DIFF
--- a/DocsCode/NavigationTutorial/NavigationTutorialViewController.swift
+++ b/DocsCode/NavigationTutorial/NavigationTutorialViewController.swift
@@ -123,11 +123,8 @@ class ViewController: UIViewController {
                 // Show the start button
                 strongSelf.startButton?.isHidden = false
                 
-                // Draw the route on the map after creating it
-                strongSelf.drawRoute(route: route)
-                
-                // Show destination waypoint on the map
-                strongSelf.navigationMapView.showWaypoints(on: route)
+                // Showcase the route and destination waypoint, and set camera
+                strongSelf.navigationMapView.showcase([route], animated: true)
             }
         }
     }


### PR DESCRIPTION
This PR changes how we display the route and destination waypoint in the tutorial app. Previously, developers were shown 

> how to use the individual `NavigationMapView.show(_:legIndex:)` and `NavigationMapView.showWaypoints(on:legIndex:)` methods, but it is better to show how to use `NavigationMapView.showcase(_:animated:) which zooms the map to fit the route. We’ve gotten some feedback from developers who were expecting that behavior but didn’t know how to get it: mapbox/ask-navigation#43 (comment). 

from [comment](https://github.com/mapbox/help/pull/2945/files#r711611233).