### PR TITLE
Changes placeholder string to YOUR_MAPBOX_ACCESS_TOKEN in token-placeholder strings

### DIFF
--- a/DocsCode/Info.plist
+++ b/DocsCode/Info.plist
@@ -21,7 +21,7 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>MBXAccessToken</key>
-	<string>PASTE MAPBOX ACCESS TOKEN HERE</string>
+	<string>YOUR_MAPBOX_ACCESS_TOKEN</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Get the user location for navigation purposes.</string>
 	<key>UIBackgroundModes</key>

--- a/Navigation-Examples/Info.plist
+++ b/Navigation-Examples/Info.plist
@@ -21,7 +21,7 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>MBXAccessToken</key>
-	<string>PASTE MAPBOX ACCESS TOKEN HERE</string>
+	<string>YOUR_MAPBOX_ACCESS_TOKEN</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Get the user location for navigation purposes.</string>
 	<key>UIBackgroundModes</key>

--- a/readme.md
+++ b/readme.md
@@ -16,9 +16,9 @@ _Installation with CocoaPods_
    ```
    machine api.mapbox.com 
      login mapbox
-     password PRIVATE_MAPBOX_API_TOKEN
+     password YOUR_PRIVATE_MAPBOX_TOKEN
    ```
-   where _PRIVATE_MAPBOX_API_TOKEN_ is your Mapbox API token with the `DOWNLOADS:READ` scope. 
+   where _YOUR_PRIVATE_MAPBOX_TOKEN_ is your Mapbox API token with the `DOWNLOADS:READ` scope. 
 1. Run `pod repo update && pod install` and open the resulting Navigation-Examples.xcworkspace.
 1. Sign up or log in to your Mapbox account and grab a [Mapbox access token](https://www.mapbox.com/help/define-access-token/).
 1. Enter your Mapbox access token into the value of the `MBXAccessToken` key within the Info.plist file. Alternatively, if you plan to use this project as the basis for any open source application, [read this guide](https://docs.mapbox.com/help/troubleshooting/private-access-token-android-and-ios/#ios) to learn how to best protect your access tokens.


### PR DESCRIPTION
Re: mapbox/documentation#773

## Description

- Replaces token placeholder string `PASTE MAPBOX ACCESS TOKEN HERE` with `YOUR_MAPBOX_ACCESS_TOKEN`
- Replaces `PRIVATE_MAPBOX_API_TOKEN` with `YOUR_PRIVATE_MAPBOX_TOKEN`

