### PR TITLE
Fix examples that advancing legIndex manually 

### DIFF
--- a/Navigation-Examples/Examples/Building-Extrusion.swift
+++ b/Navigation-Examples/Examples/Building-Extrusion.swift
@@ -250,7 +250,7 @@ class BuildingExtrusionViewController: UIViewController, NavigationMapViewDelega
             guard let navigationService = (self.presentedViewController as? NavigationViewController)?.navigationService else { return }
             let router = navigationService.router
             guard router.route.legs.count > router.routeProgress.legIndex + 1 else { return }
-            router.routeProgress.legIndex += 1
+            router.advanceLegIndex(completionHandler: nil)
             
             navigationService.start()
         })

--- a/Navigation-Examples/Examples/Waypoint-Arrival-Screen.swift
+++ b/Navigation-Examples/Examples/Waypoint-Arrival-Screen.swift
@@ -50,7 +50,7 @@ extension WaypointArrivalScreenViewController: NavigationViewControllerDelegate 
         alert.addAction(UIAlertAction(title: "Ok", style: .default, handler: { _ in
             // Begin the next leg once the driver confirms
             if !isFinalLeg {
-                navigationViewController.navigationService.routeProgress.legIndex += 1
+                navigationViewController.navigationService.router.advanceLegIndex(completionHandler: nil)
                 navigationViewController.navigationService.start()
             }
         }))


### PR DESCRIPTION
1. advanceLegIndex is the correct API for advancing legIndex
2. I've also added shared schema for examples target. It was remove it seems. 

Fixes #154