### PR TITLE
Add header to link examples to docs

### DIFF
--- a/Navigation-Examples/Examples/Advanced.swift
+++ b/Navigation-Examples/Examples/Advanced.swift
@@ -2,7 +2,7 @@
  This code example is part of the Mapbox Navigation SDK for iOS demo app,
  which you can build and run: https://github.com/mapbox/mapbox-navigation-ios-examples
  To learn more about each example in this app, including descriptions and links
- to documentation, see our docs: https://docs.mapbox.com/ios/navigation/examples
+ to documentation, see our docs: https://docs.mapbox.com/ios/navigation/examples/advanced
  */
 
 import UIKit

--- a/Navigation-Examples/Examples/Advanced.swift
+++ b/Navigation-Examples/Examples/Advanced.swift
@@ -1,3 +1,10 @@
+/*
+ This code example is part of the Mapbox Navigation SDK for iOS demo app,
+ which you can build and run: https://github.com/mapbox/mapbox-navigation-ios-examples
+ To learn more about each example in this app, including descriptions and links
+ to documentation, see our docs: https://docs.mapbox.com/ios/navigation/examples
+ */
+
 import UIKit
 import MapboxCoreNavigation
 import MapboxNavigation

--- a/Navigation-Examples/Examples/Basic.swift
+++ b/Navigation-Examples/Examples/Basic.swift
@@ -1,3 +1,10 @@
+/*
+ This code example is part of the Mapbox Navigation SDK for iOS demo app,
+ which you can build and run: https://github.com/mapbox/mapbox-navigation-ios-examples
+ To learn more about each example in this app, including descriptions and links
+ to documentation, see our docs: https://docs.mapbox.com/ios/navigation/examples
+ */
+
 import Foundation
 import UIKit
 import MapboxCoreNavigation

--- a/Navigation-Examples/Examples/Basic.swift
+++ b/Navigation-Examples/Examples/Basic.swift
@@ -2,7 +2,7 @@
  This code example is part of the Mapbox Navigation SDK for iOS demo app,
  which you can build and run: https://github.com/mapbox/mapbox-navigation-ios-examples
  To learn more about each example in this app, including descriptions and links
- to documentation, see our docs: https://docs.mapbox.com/ios/navigation/examples
+ to documentation, see our docs: https://docs.mapbox.com/ios/navigation/examples/basic
  */
 
 import Foundation

--- a/Navigation-Examples/Examples/Beta-Query-Parameters.swift
+++ b/Navigation-Examples/Examples/Beta-Query-Parameters.swift
@@ -1,3 +1,10 @@
+/*
+ This code example is part of the Mapbox Navigation SDK for iOS demo app,
+ which you can build and run: https://github.com/mapbox/mapbox-navigation-ios-examples
+ To learn more about each example in this app, including descriptions and links
+ to documentation, see our docs: https://docs.mapbox.com/ios/navigation/examples
+ */
+
 import UIKit
 import MapboxCoreNavigation
 import MapboxNavigation

--- a/Navigation-Examples/Examples/Building-Extrusion.swift
+++ b/Navigation-Examples/Examples/Building-Extrusion.swift
@@ -1,3 +1,10 @@
+/*
+ This code example is part of the Mapbox Navigation SDK for iOS demo app,
+ which you can build and run: https://github.com/mapbox/mapbox-navigation-ios-examples
+ To learn more about each example in this app, including descriptions and links
+ to documentation, see our docs: https://docs.mapbox.com/ios/navigation/examples
+ */
+
 import UIKit
 import MapboxCoreNavigation
 import MapboxNavigation

--- a/Navigation-Examples/Examples/Building-Extrusion.swift
+++ b/Navigation-Examples/Examples/Building-Extrusion.swift
@@ -2,7 +2,7 @@
  This code example is part of the Mapbox Navigation SDK for iOS demo app,
  which you can build and run: https://github.com/mapbox/mapbox-navigation-ios-examples
  To learn more about each example in this app, including descriptions and links
- to documentation, see our docs: https://docs.mapbox.com/ios/navigation/examples
+ to documentation, see our docs: https://docs.mapbox.com/ios/navigation/examples/building-extrusion
  */
 
 import UIKit

--- a/Navigation-Examples/Examples/Custom-Destination-Marker.swift
+++ b/Navigation-Examples/Examples/Custom-Destination-Marker.swift
@@ -1,3 +1,10 @@
+/*
+ This code example is part of the Mapbox Navigation SDK for iOS demo app,
+ which you can build and run: https://github.com/mapbox/mapbox-navigation-ios-examples
+ To learn more about each example in this app, including descriptions and links
+ to documentation, see our docs: https://docs.mapbox.com/ios/navigation/examples
+ */
+
 import Foundation
 import UIKit
 import MapboxCoreNavigation

--- a/Navigation-Examples/Examples/Custom-Destination-Marker.swift
+++ b/Navigation-Examples/Examples/Custom-Destination-Marker.swift
@@ -2,7 +2,7 @@
  This code example is part of the Mapbox Navigation SDK for iOS demo app,
  which you can build and run: https://github.com/mapbox/mapbox-navigation-ios-examples
  To learn more about each example in this app, including descriptions and links
- to documentation, see our docs: https://docs.mapbox.com/ios/navigation/examples
+ to documentation, see our docs: https://docs.mapbox.com/ios/navigation/examples/custom-destination-marker
  */
 
 import Foundation

--- a/Navigation-Examples/Examples/Custom-Server.swift
+++ b/Navigation-Examples/Examples/Custom-Server.swift
@@ -1,3 +1,10 @@
+/*
+ This code example is part of the Mapbox Navigation SDK for iOS demo app,
+ which you can build and run: https://github.com/mapbox/mapbox-navigation-ios-examples
+ To learn more about each example in this app, including descriptions and links
+ to documentation, see our docs: https://docs.mapbox.com/ios/navigation/examples
+ */
+
 import Foundation
 import UIKit
 import MapboxMaps

--- a/Navigation-Examples/Examples/Custom-Server.swift
+++ b/Navigation-Examples/Examples/Custom-Server.swift
@@ -2,7 +2,7 @@
  This code example is part of the Mapbox Navigation SDK for iOS demo app,
  which you can build and run: https://github.com/mapbox/mapbox-navigation-ios-examples
  To learn more about each example in this app, including descriptions and links
- to documentation, see our docs: https://docs.mapbox.com/ios/navigation/examples
+ to documentation, see our docs: https://docs.mapbox.com/ios/navigation/examples/custom-server
  */
 
 import Foundation

--- a/Navigation-Examples/Examples/Custom-User-Location.swift
+++ b/Navigation-Examples/Examples/Custom-User-Location.swift
@@ -2,7 +2,7 @@
  This code example is part of the Mapbox Navigation SDK for iOS demo app,
  which you can build and run: https://github.com/mapbox/mapbox-navigation-ios-examples
  To learn more about each example in this app, including descriptions and links
- to documentation, see our docs: https://docs.mapbox.com/ios/navigation/examples
+ to documentation, see our docs: https://docs.mapbox.com/ios/navigation/examples/custom-location-indicator
  */
 
 import UIKit

--- a/Navigation-Examples/Examples/Custom-User-Location.swift
+++ b/Navigation-Examples/Examples/Custom-User-Location.swift
@@ -1,3 +1,10 @@
+/*
+ This code example is part of the Mapbox Navigation SDK for iOS demo app,
+ which you can build and run: https://github.com/mapbox/mapbox-navigation-ios-examples
+ To learn more about each example in this app, including descriptions and links
+ to documentation, see our docs: https://docs.mapbox.com/ios/navigation/examples
+ */
+
 import UIKit
 import MapboxCoreNavigation
 import MapboxNavigation

--- a/Navigation-Examples/Examples/Custom-Voice-Controller.swift
+++ b/Navigation-Examples/Examples/Custom-Voice-Controller.swift
@@ -1,3 +1,10 @@
+/*
+ This code example is part of the Mapbox Navigation SDK for iOS demo app,
+ which you can build and run: https://github.com/mapbox/mapbox-navigation-ios-examples
+ To learn more about each example in this app, including descriptions and links
+ to documentation, see our docs: https://docs.mapbox.com/ios/navigation/examples
+ */
+
 import Foundation
 import UIKit
 import MapboxCoreNavigation

--- a/Navigation-Examples/Examples/Custom-Waypoints.swift
+++ b/Navigation-Examples/Examples/Custom-Waypoints.swift
@@ -2,7 +2,7 @@
  This code example is part of the Mapbox Navigation SDK for iOS demo app,
  which you can build and run: https://github.com/mapbox/mapbox-navigation-ios-examples
  To learn more about each example in this app, including descriptions and links
- to documentation, see our docs: https://docs.mapbox.com/ios/navigation/examples
+ to documentation, see our docs: https://docs.mapbox.com/ios/navigation/examples/custom-waypoint
  */
 
 import UIKit

--- a/Navigation-Examples/Examples/Custom-Waypoints.swift
+++ b/Navigation-Examples/Examples/Custom-Waypoints.swift
@@ -1,3 +1,10 @@
+/*
+ This code example is part of the Mapbox Navigation SDK for iOS demo app,
+ which you can build and run: https://github.com/mapbox/mapbox-navigation-ios-examples
+ To learn more about each example in this app, including descriptions and links
+ to documentation, see our docs: https://docs.mapbox.com/ios/navigation/examples
+ */
+
 import UIKit
 import MapboxCoreNavigation
 import MapboxNavigation

--- a/Navigation-Examples/Examples/CustomBars/CustomBarsViewController.swift
+++ b/Navigation-Examples/Examples/CustomBars/CustomBarsViewController.swift
@@ -1,3 +1,10 @@
+/*
+ This code example is part of the Mapbox Navigation SDK for iOS demo app,
+ which you can build and run: https://github.com/mapbox/mapbox-navigation-ios-examples
+ To learn more about each example in this app, including descriptions and links
+ to documentation, see our docs: https://docs.mapbox.com/ios/navigation/examples/custom-banner
+ */
+
 import Foundation
 import UIKit
 import MapboxCoreNavigation

--- a/Navigation-Examples/Examples/CustomSegue/Navigation-From-Segue.swift
+++ b/Navigation-Examples/Examples/CustomSegue/Navigation-From-Segue.swift
@@ -1,3 +1,10 @@
+/*
+ This code example is part of the Mapbox Navigation SDK for iOS demo app,
+ which you can build and run: https://github.com/mapbox/mapbox-navigation-ios-examples
+ To learn more about each example in this app, including descriptions and links
+ to documentation, see our docs: https://docs.mapbox.com/ios/navigation/examples/custom-segue
+ */
+
 import UIKit
 import MapboxNavigation
 import MapboxCoreNavigation

--- a/Navigation-Examples/Examples/Embedded-Navigation.swift
+++ b/Navigation-Examples/Examples/Embedded-Navigation.swift
@@ -1,3 +1,10 @@
+/*
+ This code example is part of the Mapbox Navigation SDK for iOS demo app,
+ which you can build and run: https://github.com/mapbox/mapbox-navigation-ios-examples
+ To learn more about each example in this app, including descriptions and links
+ to documentation, see our docs: https://docs.mapbox.com/ios/navigation/examples
+ */
+
 import Foundation
 import MapboxCoreNavigation
 import MapboxNavigation

--- a/Navigation-Examples/Examples/Embedded-Navigation.swift
+++ b/Navigation-Examples/Examples/Embedded-Navigation.swift
@@ -2,7 +2,7 @@
  This code example is part of the Mapbox Navigation SDK for iOS demo app,
  which you can build and run: https://github.com/mapbox/mapbox-navigation-ios-examples
  To learn more about each example in this app, including descriptions and links
- to documentation, see our docs: https://docs.mapbox.com/ios/navigation/examples
+ to documentation, see our docs: https://docs.mapbox.com/ios/navigation/examples/embedded-navigation
  */
 
 import Foundation

--- a/Navigation-Examples/Examples/Location-Snapping.swift
+++ b/Navigation-Examples/Examples/Location-Snapping.swift
@@ -1,3 +1,10 @@
+/*
+ This code example is part of the Mapbox Navigation SDK for iOS demo app,
+ which you can build and run: https://github.com/mapbox/mapbox-navigation-ios-examples
+ To learn more about each example in this app, including descriptions and links
+ to documentation, see our docs: https://docs.mapbox.com/ios/navigation/examples
+ */
+
 import UIKit
 import MapboxNavigation
 import MapboxCoreNavigation

--- a/Navigation-Examples/Examples/Location-Snapping.swift
+++ b/Navigation-Examples/Examples/Location-Snapping.swift
@@ -2,7 +2,7 @@
  This code example is part of the Mapbox Navigation SDK for iOS demo app,
  which you can build and run: https://github.com/mapbox/mapbox-navigation-ios-examples
  To learn more about each example in this app, including descriptions and links
- to documentation, see our docs: https://docs.mapbox.com/ios/navigation/examples
+ to documentation, see our docs: https://docs.mapbox.com/ios/navigation/examples/location-snapping
  */
 
 import UIKit

--- a/Navigation-Examples/Examples/NavigationCamera/Custom-Navigation-Camera.swift
+++ b/Navigation-Examples/Examples/NavigationCamera/Custom-Navigation-Camera.swift
@@ -1,3 +1,10 @@
+/*
+ This code example is part of the Mapbox Navigation SDK for iOS demo app,
+ which you can build and run: https://github.com/mapbox/mapbox-navigation-ios-examples
+ To learn more about each example in this app, including descriptions and links
+ to documentation, see our docs: https://docs.mapbox.com/ios/navigation/examples/custom-navigation-camera
+ */
+
 import UIKit
 import MapboxNavigation
 import MapboxMaps

--- a/Navigation-Examples/Examples/Offline-Regions.swift
+++ b/Navigation-Examples/Examples/Offline-Regions.swift
@@ -1,3 +1,10 @@
+/*
+ This code example is part of the Mapbox Navigation SDK for iOS demo app,
+ which you can build and run: https://github.com/mapbox/mapbox-navigation-ios-examples
+ To learn more about each example in this app, including descriptions and links
+ to documentation, see our docs: https://docs.mapbox.com/ios/navigation/examples
+ */
+
 import UIKit
 import MapboxCoreNavigation
 import MapboxNavigationNative

--- a/Navigation-Examples/Examples/Predictive-Caching.swift
+++ b/Navigation-Examples/Examples/Predictive-Caching.swift
@@ -2,7 +2,7 @@
  This code example is part of the Mapbox Navigation SDK for iOS demo app,
  which you can build and run: https://github.com/mapbox/mapbox-navigation-ios-examples
  To learn more about each example in this app, including descriptions and links
- to documentation, see our docs: https://docs.mapbox.com/ios/navigation/examples
+ to documentation, see our docs: https://docs.mapbox.com/ios/navigation/examples/predictive-caching
  */
 
 import UIKit

--- a/Navigation-Examples/Examples/Predictive-Caching.swift
+++ b/Navigation-Examples/Examples/Predictive-Caching.swift
@@ -1,3 +1,10 @@
+/*
+ This code example is part of the Mapbox Navigation SDK for iOS demo app,
+ which you can build and run: https://github.com/mapbox/mapbox-navigation-ios-examples
+ To learn more about each example in this app, including descriptions and links
+ to documentation, see our docs: https://docs.mapbox.com/ios/navigation/examples
+ */
+
 import UIKit
 import MapboxCoreNavigation
 import MapboxNavigation

--- a/Navigation-Examples/Examples/Route-Alerts.swift
+++ b/Navigation-Examples/Examples/Route-Alerts.swift
@@ -2,7 +2,7 @@
  This code example is part of the Mapbox Navigation SDK for iOS demo app,
  which you can build and run: https://github.com/mapbox/mapbox-navigation-ios-examples
  To learn more about each example in this app, including descriptions and links
- to documentation, see our docs: https://docs.mapbox.com/ios/navigation/examples
+ to documentation, see our docs: https://docs.mapbox.com/ios/navigation/examples/route-alerts
  */
 
 import UIKit

--- a/Navigation-Examples/Examples/Route-Alerts.swift
+++ b/Navigation-Examples/Examples/Route-Alerts.swift
@@ -1,3 +1,10 @@
+/*
+ This code example is part of the Mapbox Navigation SDK for iOS demo app,
+ which you can build and run: https://github.com/mapbox/mapbox-navigation-ios-examples
+ To learn more about each example in this app, including descriptions and links
+ to documentation, see our docs: https://docs.mapbox.com/ios/navigation/examples
+ */
+
 import UIKit
 import MapboxCoreNavigation
 import MapboxNavigation

--- a/Navigation-Examples/Examples/Route-Deserialization.swift
+++ b/Navigation-Examples/Examples/Route-Deserialization.swift
@@ -2,7 +2,7 @@
  This code example is part of the Mapbox Navigation SDK for iOS demo app,
  which you can build and run: https://github.com/mapbox/mapbox-navigation-ios-examples
  To learn more about each example in this app, including descriptions and links
- to documentation, see our docs: https://docs.mapbox.com/ios/navigation/examples
+ to documentation, see our docs: https://docs.mapbox.com/ios/navigation/examples/route-deserialization
  */
 
 import UIKit

--- a/Navigation-Examples/Examples/Route-Deserialization.swift
+++ b/Navigation-Examples/Examples/Route-Deserialization.swift
@@ -1,3 +1,10 @@
+/*
+ This code example is part of the Mapbox Navigation SDK for iOS demo app,
+ which you can build and run: https://github.com/mapbox/mapbox-navigation-ios-examples
+ To learn more about each example in this app, including descriptions and links
+ to documentation, see our docs: https://docs.mapbox.com/ios/navigation/examples
+ */
+
 import UIKit
 import MapboxCoreNavigation
 import MapboxNavigation

--- a/Navigation-Examples/Examples/Route-Initialization.swift
+++ b/Navigation-Examples/Examples/Route-Initialization.swift
@@ -2,7 +2,7 @@
  This code example is part of the Mapbox Navigation SDK for iOS demo app,
  which you can build and run: https://github.com/mapbox/mapbox-navigation-ios-examples
  To learn more about each example in this app, including descriptions and links
- to documentation, see our docs: https://docs.mapbox.com/ios/navigation/examples
+ to documentation, see our docs: https://docs.mapbox.com/ios/navigation/examples/route-initialization
  */
 
 import UIKit

--- a/Navigation-Examples/Examples/Route-Initialization.swift
+++ b/Navigation-Examples/Examples/Route-Initialization.swift
@@ -1,3 +1,10 @@
+/*
+ This code example is part of the Mapbox Navigation SDK for iOS demo app,
+ which you can build and run: https://github.com/mapbox/mapbox-navigation-ios-examples
+ To learn more about each example in this app, including descriptions and links
+ to documentation, see our docs: https://docs.mapbox.com/ios/navigation/examples
+ */
+
 import UIKit
 import MapboxCoreNavigation
 import MapboxNavigation

--- a/Navigation-Examples/Examples/Route-Lines-Styling.swift
+++ b/Navigation-Examples/Examples/Route-Lines-Styling.swift
@@ -2,7 +2,7 @@
  This code example is part of the Mapbox Navigation SDK for iOS demo app,
  which you can build and run: https://github.com/mapbox/mapbox-navigation-ios-examples
  To learn more about each example in this app, including descriptions and links
- to documentation, see our docs: https://docs.mapbox.com/ios/navigation/examples
+ to documentation, see our docs: https://docs.mapbox.com/ios/navigation/examples/route-lines-styling
  */
 
 import UIKit

--- a/Navigation-Examples/Examples/Route-Lines-Styling.swift
+++ b/Navigation-Examples/Examples/Route-Lines-Styling.swift
@@ -1,3 +1,10 @@
+/*
+ This code example is part of the Mapbox Navigation SDK for iOS demo app,
+ which you can build and run: https://github.com/mapbox/mapbox-navigation-ios-examples
+ To learn more about each example in this app, including descriptions and links
+ to documentation, see our docs: https://docs.mapbox.com/ios/navigation/examples
+ */
+
 import UIKit
 import MapboxCoreNavigation
 import MapboxNavigation

--- a/Navigation-Examples/Examples/Styled-UI-Elements.swift
+++ b/Navigation-Examples/Examples/Styled-UI-Elements.swift
@@ -2,7 +2,7 @@
  This code example is part of the Mapbox Navigation SDK for iOS demo app,
  which you can build and run: https://github.com/mapbox/mapbox-navigation-ios-examples
  To learn more about each example in this app, including descriptions and links
- to documentation, see our docs: https://docs.mapbox.com/ios/navigation/examples
+ to documentation, see our docs: https://docs.mapbox.com/ios/navigation/examples/styled-ui-elements
  */
 
 import Foundation

--- a/Navigation-Examples/Examples/Styled-UI-Elements.swift
+++ b/Navigation-Examples/Examples/Styled-UI-Elements.swift
@@ -1,3 +1,10 @@
+/*
+ This code example is part of the Mapbox Navigation SDK for iOS demo app,
+ which you can build and run: https://github.com/mapbox/mapbox-navigation-ios-examples
+ To learn more about each example in this app, including descriptions and links
+ to documentation, see our docs: https://docs.mapbox.com/ios/navigation/examples
+ */
+
 import Foundation
 import UIKit
 import MapboxCoreNavigation

--- a/Navigation-Examples/Examples/Upcoming-Intersection.swift
+++ b/Navigation-Examples/Examples/Upcoming-Intersection.swift
@@ -1,3 +1,10 @@
+/*
+ This code example is part of the Mapbox Navigation SDK for iOS demo app,
+ which you can build and run: https://github.com/mapbox/mapbox-navigation-ios-examples
+ To learn more about each example in this app, including descriptions and links
+ to documentation, see our docs: https://docs.mapbox.com/ios/navigation/examples
+ */
+
 import UIKit
 import MapboxNavigation
 import MapboxCoreNavigation

--- a/Navigation-Examples/Examples/Upcoming-Intersection.swift
+++ b/Navigation-Examples/Examples/Upcoming-Intersection.swift
@@ -2,7 +2,7 @@
  This code example is part of the Mapbox Navigation SDK for iOS demo app,
  which you can build and run: https://github.com/mapbox/mapbox-navigation-ios-examples
  To learn more about each example in this app, including descriptions and links
- to documentation, see our docs: https://docs.mapbox.com/ios/navigation/examples
+ to documentation, see our docs: https://docs.mapbox.com/ios/navigation/examples/electronic-horizon
  */
 
 import UIKit

--- a/Navigation-Examples/Examples/Waypoint-Arrival-Screen.swift
+++ b/Navigation-Examples/Examples/Waypoint-Arrival-Screen.swift
@@ -1,3 +1,10 @@
+/*
+ This code example is part of the Mapbox Navigation SDK for iOS demo app,
+ which you can build and run: https://github.com/mapbox/mapbox-navigation-ios-examples
+ To learn more about each example in this app, including descriptions and links
+ to documentation, see our docs: https://docs.mapbox.com/ios/navigation/examples
+ */
+
 import Foundation
 import UIKit
 import MapboxCoreNavigation

--- a/Navigation-Examples/Examples/Waypoint-Arrival-Screen.swift
+++ b/Navigation-Examples/Examples/Waypoint-Arrival-Screen.swift
@@ -2,7 +2,7 @@
  This code example is part of the Mapbox Navigation SDK for iOS demo app,
  which you can build and run: https://github.com/mapbox/mapbox-navigation-ios-examples
  To learn more about each example in this app, including descriptions and links
- to documentation, see our docs: https://docs.mapbox.com/ios/navigation/examples
+ to documentation, see our docs: https://docs.mapbox.com/ios/navigation/examples/waypoint-arrival-screen
  */
 
 import Foundation


### PR DESCRIPTION
Closes #133 

This PR adds a brief header to each example (see below) that links to the Mapbox documentation page. This header will appear in the example code in the repo and in the code snippet on the docs examples page. Additional changes will add descriptions to each docs examples page. 

>  This code example is part of the Mapbox Navigation SDK for iOS demo app,
>  which you can build and run: https://github.com/mapbox/mapbox-navigation-ios-examples
>  To learn more about each example in this app, including descriptions and links
>  to documentation, see our docs: https://docs.mapbox.com/ios/navigation/examples