### PR TITLE
Upgrade to MapboxNavigation v2.2.0

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,28 +1,28 @@
 PODS:
-  - MapboxCommon (20.1.2)
-  - MapboxCoreMaps (10.1.1):
-    - MapboxCommon (~> 20.1)
-  - MapboxCoreNavigation (2.1.1):
-    - MapboxDirections (~> 2.1)
+  - MapboxCommon (21.0.1)
+  - MapboxCoreMaps (10.2.0):
+    - MapboxCommon (~> 21.0)
+  - MapboxCoreNavigation (2.2.0):
+    - MapboxDirections (~> 2.2.0)
     - MapboxMobileEvents (~> 1.0)
-    - MapboxNavigationNative (~> 80.0)
-  - MapboxDirections (2.1.0):
+    - MapboxNavigationNative (~> 83.0)
+  - MapboxDirections (2.2.0):
     - Polyline (~> 5.0)
     - Turf (~> 2.0)
-  - MapboxMaps (10.1.2):
-    - MapboxCommon (= 20.1.2)
-    - MapboxCoreMaps (= 10.1.1)
+  - MapboxMaps (10.2.0):
+    - MapboxCommon (= 21.0.1)
+    - MapboxCoreMaps (= 10.2.0)
     - MapboxMobileEvents (= 1.0.6)
     - Turf (~> 2.0)
   - MapboxMobileEvents (1.0.6)
-  - MapboxNavigation (2.1.1):
-    - MapboxCoreNavigation (= 2.1.1)
-    - MapboxMaps (< 11.0.0, >= 10.1.1)
+  - MapboxNavigation (2.2.0):
+    - MapboxCoreNavigation (= 2.2.0)
+    - MapboxMaps (= 10.2.0)
     - MapboxMobileEvents (~> 1.0)
     - MapboxSpeech (~> 2.0)
     - Solar-dev (~> 3.0)
-  - MapboxNavigationNative (80.0.2):
-    - MapboxCommon (~> 20.1)
+  - MapboxNavigationNative (83.0.0):
+    - MapboxCommon (~> 21.0)
   - MapboxSpeech (2.0.0)
   - Polyline (5.0.2)
   - Solar-dev (3.0.1)
@@ -48,14 +48,14 @@ SPEC REPOS:
     - Turf
 
 SPEC CHECKSUMS:
-  MapboxCommon: f15bb4cc4810d8d72e2d72bf2295f3f0cb328b11
-  MapboxCoreMaps: ee3d7f31efbbafe81ce33907b6a96066e111a244
-  MapboxCoreNavigation: 90cfee78d9a7aeada16468e6ad9cbf425c41acc3
-  MapboxDirections: f9787126bb46a3c9164978761ccdafccdbad1220
-  MapboxMaps: e4c4620a76b9e26a5d6cae10ffee5681a135b3de
+  MapboxCommon: fdfdbd4e87a225190913f2f4b4a73ec51ed77eaa
+  MapboxCoreMaps: bdd0115bfd8bf6df402468710cb23c926938b03d
+  MapboxCoreNavigation: 12d31f4dd5bd08120097ec52c540a032fd58f4de
+  MapboxDirections: aaa6f1ae1612692ef3b4211d20d22404ad8ef607
+  MapboxMaps: 1ed477cbe573a9e740801dfc9c636ef33bbc3f54
   MapboxMobileEvents: 14d7ac3ee95b4142c4fec2205dfd48ff453e8871
-  MapboxNavigation: ae52148971b92fd0b5735b15db7f5b1feb13906f
-  MapboxNavigationNative: 5319134183246da72d3ad7f4d4089452ce450167
+  MapboxNavigation: 77fce7e09f1323a1f10c5ee5d9c238aaee2d7d85
+  MapboxNavigationNative: a82594cb6fa26c129e2f1a08d1466c3f98cdc999
   MapboxSpeech: e4ed02984444b6373374c72c369edaf045cc490c
   Polyline: fce41d72e1146c41c6d081f7656827226f643dff
   Solar-dev: 4612dc9878b9fed2667d23b327f1d4e54e16e8d0


### PR DESCRIPTION
This PR is to upgrade to `MapboxNavigation` `v2.2.0`.