### PR TITLE
Custom RoutingProvider example

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
     parameters:
       xcode:
         type: string
-        default: "12.4"
+        default: "13.0"
       device:
         type: string
         default: "iPhone 8 Plus"
@@ -47,8 +47,8 @@ workflows:
   workflow:
     jobs:
       - build-job:
-          name: "Xcode_12.4_iOS_14.4"
-          xcode: "12.4.0"
+          name: "Xcode_13.0_iOS_14.4"
+          xcode: "13.0.0"
           ios: "14.4"
           device: "iPhone 11 Pro"
       - build-job:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
         default: "iPhone 8 Plus"
       ios:
         type: string
-        default: "14.4"
+        default: "14.5"
     macos:
       xcode: << parameters.xcode >>
     steps:
@@ -47,9 +47,9 @@ workflows:
   workflow:
     jobs:
       - build-job:
-          name: "Xcode_13.0_iOS_14.4"
+          name: "Xcode_13.0_iOS_14.5"
           xcode: "13.0.0"
-          ios: "14.4"
+          ios: "14.5"
           device: "iPhone 11 Pro"
       - build-job:
           name: "Xcode_13.0_iOS_15.0"

--- a/Navigation-Examples.xcodeproj/project.pbxproj
+++ b/Navigation-Examples.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		2B521D4E24090A3A00984CF8 /* CustomBarsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B521D4D24090A3A00984CF8 /* CustomBarsViewController.swift */; };
 		2B521D502409240E00984CF8 /* CustomBottomBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B521D4F2409240E00984CF8 /* CustomBottomBannerView.swift */; };
 		2B521D522409242A00984CF8 /* CustomBottomBannerView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 2B521D512409242A00984CF8 /* CustomBottomBannerView.xib */; };
+		2B5470632816C74A0068DA3F /* Custom-RoutingProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B5470622816C74A0068DA3F /* Custom-RoutingProvider.swift */; };
 		8A0B182326553482005107DE /* CustomSegue.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8A0B182226553482005107DE /* CustomSegue.storyboard */; };
 		8A2DFA57261650A60034A87E /* CustomCameraStateTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2DFA55261650A60034A87E /* CustomCameraStateTransition.swift */; };
 		8A2DFA58261650A60034A87E /* CustomViewportDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2DFA56261650A60034A87E /* CustomViewportDataSource.swift */; };
@@ -61,6 +62,7 @@
 		2B521D4D24090A3A00984CF8 /* CustomBarsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomBarsViewController.swift; sourceTree = "<group>"; };
 		2B521D4F2409240E00984CF8 /* CustomBottomBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomBottomBannerView.swift; sourceTree = "<group>"; };
 		2B521D512409242A00984CF8 /* CustomBottomBannerView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CustomBottomBannerView.xib; sourceTree = "<group>"; };
+		2B5470622816C74A0068DA3F /* Custom-RoutingProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Custom-RoutingProvider.swift"; sourceTree = "<group>"; };
 		4EF74F60792B221A1A61A3CE /* Pods-Navigation-Examples.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Navigation-Examples.debug.xcconfig"; path = "Target Support Files/Pods-Navigation-Examples/Pods-Navigation-Examples.debug.xcconfig"; sourceTree = "<group>"; };
 		8A0B182226553482005107DE /* CustomSegue.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = CustomSegue.storyboard; sourceTree = "<group>"; };
 		8A2DFA55261650A60034A87E /* CustomCameraStateTransition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomCameraStateTransition.swift; sourceTree = "<group>"; };
@@ -254,6 +256,7 @@
 				C52BAA772040D5030086EC6B /* Custom-Destination-Marker.swift */,
 				C5C0D63720589422003A3B1D /* Custom-Server.swift */,
 				C3893F1B25F96BDC0058A987 /* Custom-Waypoints.swift */,
+				2B5470622816C74A0068DA3F /* Custom-RoutingProvider.swift */,
 				8AE033212628EDFF000E7145 /* Route-Lines-Styling.swift */,
 				8A96379A2492B366008DEF2A /* Route-Deserialization.swift */,
 				8AC9129C2494106100B6941E /* Route-Initialization.swift */,
@@ -636,6 +639,7 @@
 				C52BAA782040D5030086EC6B /* Custom-Destination-Marker.swift in Sources */,
 				8DF510741FEB08F70049DB9C /* Embedded-Navigation.swift in Sources */,
 				11B6E81726176F3600872E4D /* Upcoming-Intersection.swift in Sources */,
+				2B5470632816C74A0068DA3F /* Custom-RoutingProvider.swift in Sources */,
 				C58FB8711FE8A43000C4B491 /* Basic.swift in Sources */,
 				8A2DFA57261650A60034A87E /* CustomCameraStateTransition.swift in Sources */,
 				C58FB8731FE98AEB00C4B491 /* Styled-UI-Elements.swift in Sources */,

--- a/Navigation-Examples/Constants.swift
+++ b/Navigation-Examples/Constants.swift
@@ -174,5 +174,12 @@ let listOfExamples: [NamedController] = [
         controller: OfflineRegionsViewController.self,
         storyboard: nil,
         pushExampleToViewController: true
+    ),
+    (
+        name: "Custom RoutingProvider",
+        description: "Demonstrates how to implement and utilize custom `RoutingProvider`.",
+        controller: CustomRoutingProviderViewController.self,
+        storyboard: nil,
+        pushExampleToViewController: true
     )
 ]

--- a/Navigation-Examples/Examples/Custom-RoutingProvider.swift
+++ b/Navigation-Examples/Examples/Custom-RoutingProvider.swift
@@ -11,6 +11,9 @@ import MapboxCoreNavigation
 import MapboxNavigation
 import MapboxDirections
 
+/*
+ This example demonstrates how users can control and customize the rerouting process. Unlike `Custom-Server` example, this one does not completely cancel SDK mechanism to do it separately, but instead controls just the part of new route calculation, preserving original workflow and events. In result, any related components will not know that rerouting was altered and will react as on usual reroute event.
+ */
 class CustomRoutingProviderViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -51,7 +54,6 @@ class CustomRoutingProviderViewController: UIViewController {
         })
     }
 }
-
 
 class CustomProvider: RoutingProvider {
     // This can encapsulate any route building engine we need. For simplicity let's use `MapboxRoutingProvider`.
@@ -133,6 +135,4 @@ class CustomProvider: RoutingProvider {
                             .failure(.unableToRoute))
         return nil
     }
-    
-    
 }

--- a/Navigation-Examples/Examples/Custom-RoutingProvider.swift
+++ b/Navigation-Examples/Examples/Custom-RoutingProvider.swift
@@ -12,7 +12,11 @@ import MapboxNavigation
 import MapboxDirections
 
 /*
- This example demonstrates how users can control and customize the rerouting process. Unlike `Custom-Server` example, this one does not completely cancel SDK mechanism to do it separately, but instead controls just the part of new route calculation, preserving original workflow and events. In result, any related components will not know that rerouting was altered and will react as on usual reroute event.
+ This example demonstrates how users can control and customize the rerouting process.
+ Unlike `Custom-Server` example, this one does not completely cancel SDK mechanism to do it
+ separately, but instead controls just the part of new route calculation, preserving original
+ workflow and events. In result, any related components will not know that rerouting was altered
+ and will react as on usual reroute event.
  */
 class CustomRoutingProviderViewController: UIViewController {
     override func viewDidLoad() {
@@ -92,7 +96,6 @@ class CustomProvider: RoutingProvider {
     // MARK: RoutingProvider implementation
     
     func calculateRoutes(options: RouteOptions, completionHandler: @escaping Directions.RouteCompletionHandler) -> NavigationProviderRequest? {
-        
         applyOptionsModification(options)
         
         // Using `MapboxRoutingProvider` also illustrates cases when we need to modify just a part of the route, or dynamically edit `RouteOptions` for each reroute.
@@ -101,7 +104,6 @@ class CustomProvider: RoutingProvider {
     }
     
     func calculateRoutes(options: MatchOptions, completionHandler: @escaping Directions.MatchCompletionHandler) -> NavigationProviderRequest? {
-        
         applyOptionsModification(options)
         
         return routeCalculator.calculateRoutes(options: options,

--- a/Navigation-Examples/Examples/Custom-RoutingProvider.swift
+++ b/Navigation-Examples/Examples/Custom-RoutingProvider.swift
@@ -1,0 +1,138 @@
+/*
+ This code example is part of the Mapbox Navigation SDK for iOS demo app,
+ which you can build and run: https://github.com/mapbox/mapbox-navigation-ios-examples
+ To learn more about each example in this app, including descriptions and links
+ to documentation, see our docs: https://docs.mapbox.com/ios/navigation/examples/basic
+ */
+
+import Foundation
+import UIKit
+import MapboxCoreNavigation
+import MapboxNavigation
+import MapboxDirections
+
+class CustomRoutingProviderViewController: UIViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        let origin = CLLocationCoordinate2DMake(37.77440680146262, -122.43539772352648)
+        let destination = CLLocationCoordinate2DMake(37.76556957793795, -122.42409811526268)
+        let options = NavigationRouteOptions(coordinates: [origin, destination])
+        
+        // This example is similar to `BasicViewController` except that we are using our custom `RoutingProvider` implementation for retrieving routes.
+        let customRoutingProvider = CustomProvider()
+        
+        _ = customRoutingProvider.calculateRoutes(options: options, completionHandler: { [weak self] (_, result) in
+            switch result {
+            case .failure(let error):
+                print(error.localizedDescription)
+            case .success(let response):
+                guard let strongSelf = self else {
+                    return
+                }
+                
+                let navigationService = MapboxNavigationService(routeResponse: response,
+                                                                routeIndex: 0,
+                                                                routeOptions: options,
+                                                                routingProvider: customRoutingProvider, // passing `customRoutingProvider` to ensure it is used for re-routing and refreshing
+                                                                credentials: NavigationSettings.shared.directions.credentials,
+                                                                simulating: simulationIsEnabled ? .always : .onPoorGPS)
+                
+                let navigationOptions = NavigationOptions(navigationService: navigationService)
+                let navigationViewController = NavigationViewController(for: response,
+                                                                           routeIndex: 0,
+                                                                           routeOptions: options,
+                                                                           navigationOptions: navigationOptions)
+                navigationViewController.modalPresentationStyle = .fullScreen
+                navigationViewController.routeLineTracksTraversal = true
+                
+                strongSelf.present(navigationViewController, animated: true, completion: nil)
+            }
+        })
+    }
+}
+
+
+class CustomProvider: RoutingProvider {
+    // This can encapsulate any route building engine we need. For simplicity let's use `MapboxRoutingProvider`.
+    let routeCalculator = MapboxRoutingProvider()
+    
+    // We can also modify the options used to calculate a route.
+    func applyOptionsModification(_ options: DirectionsOptions) {
+        options.attributeOptions = [.congestionLevel, .speed, .maximumSpeedLimit, .expectedTravelTime]
+    }
+    
+    // Here any manipulations on the reponse data can take place
+    func applyMapMatchingModifications(_ response: MapMatchingResponse) {
+        response.matches?.forEach { match in
+            match.legs.forEach { leg in
+                leg.incidents = fetchExternalIncidents(for: leg)
+            }
+        }
+    }
+    
+    // Let's say we have an external source of incidents data, we want to apply to the route.
+    func fetchExternalIncidents(for leg: RouteLeg) -> [Incident] {
+        return [Incident(identifier: "\(leg.name) incident",
+                         type: .otherNews,
+                         description: "Custom Incident",
+                         creationDate: Date(),
+                         startDate: Date(),
+                         endDate: Date().addingTimeInterval(60),
+                         impact: nil,
+                         subtype: nil,
+                         subtypeDescription: nil,
+                         alertCodes: [],
+                         lanesBlocked: nil,
+                         shapeIndexRange: 0..<1)]
+    }
+    
+    // MARK: RoutingProvider implementation
+    
+    func calculateRoutes(options: RouteOptions, completionHandler: @escaping Directions.RouteCompletionHandler) -> NavigationProviderRequest? {
+        
+        applyOptionsModification(options)
+        
+        // Using `MapboxRoutingProvider` also illustrates cases when we need to modify just a part of the route, or dynamically edit `RouteOptions` for each reroute.
+        return routeCalculator.calculateRoutes(options: options,
+                                               completionHandler: completionHandler)
+    }
+    
+    func calculateRoutes(options: MatchOptions, completionHandler: @escaping Directions.MatchCompletionHandler) -> NavigationProviderRequest? {
+        
+        applyOptionsModification(options)
+        
+        return routeCalculator.calculateRoutes(options: options,
+                                               completionHandler: { [weak self] (session, result) in
+            switch result {
+            case .failure(_):
+                completionHandler(session, result)
+            case .success(let response):
+                guard let strongSelf = self else {
+                    return
+                }
+                strongSelf.applyMapMatchingModifications(response)
+                
+                completionHandler(session, .success(response))
+            }
+        })
+    }
+    
+    // Let's make our custom routing provider prevent route refreshes.
+    func refreshRoute(indexedRouteResponse: IndexedRouteResponse, fromLegAtIndex: UInt32, completionHandler: @escaping Directions.RouteCompletionHandler) -> NavigationProviderRequest? {
+        
+        var options: DirectionsOptions!
+        switch indexedRouteResponse.routeResponse.options {
+        case.match(let matchOptions):
+            options = matchOptions
+        case .route(let routeOptions):
+            options = routeOptions
+        }
+        
+        completionHandler((options, NavigationSettings.shared.directions.credentials),
+                            .failure(.unableToRoute))
+        return nil
+    }
+    
+    
+}


### PR DESCRIPTION
PR adds example of custom implementation of `RoutingProvider`. Custom implementation demonstrates modifying `options`, manipulating the response data, forwarding request to a default implementation and silently disabling a request.