### PR TITLE
Update Example to MapboxNavigation 2.5

### DIFF
--- a/Navigation-Examples/Examples/Upcoming-Intersection.swift
+++ b/Navigation-Examples/Examples/Upcoming-Intersection.swift
@@ -145,7 +145,7 @@ class ElectronicHorizonEventsViewController: UIViewController {
         var edge: RoadGraph.Edge? = edge
         totalDistance = 0.0
         
-        // Update the route line shape and total distance of the most propable path.
+        // Update the route line shape and total distance of the most probable path.
         while let currentEdge = edge {
             if let shape = roadGraph.edgeShape(edgeIdentifier: currentEdge.identifier) {
                 coordinates.append(contentsOf: shape.coordinates.dropFirst(coordinates.isEmpty ? 0 : 1))
@@ -167,8 +167,8 @@ class ElectronicHorizonEventsViewController: UIViewController {
     private func updateMostProbablePathLayer(fractionFromStart: Double,
                                              roadGraph: RoadGraph,
                                              currentEdge: RoadGraph.Edge.Identifier) {
-        // Based on the length of current edge and the total distance of the most propable path (MPP),
-        // calculate the fraction of the point traveled distance to the whole most propable path (MPP).
+        // Based on the length of current edge and the total distance of the most probable path (MPP),
+        // calculate the fraction of the point traveled distance to the whole most probable path (MPP).
         if totalDistance > 0.0,
            let currentLength = roadGraph.edgeMetadata(edgeIdentifier: currentEdge)?.length {
             let fraction = fractionFromStart * currentLength / totalDistance

--- a/Podfile
+++ b/Podfile
@@ -3,8 +3,8 @@ install! 'cocoapods', :warn_for_unused_master_specs_repo => false
 platform :ios, '11.0'
 use_frameworks!
 
-pod 'MapboxCoreNavigation', '~> 2.0'
-pod 'MapboxNavigation', '~> 2.0'
+pod 'MapboxCoreNavigation', '~> 2.5.0'
+pod 'MapboxNavigation', '~> 2.5.0'
 
 target 'Navigation-Examples' do
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,36 +1,36 @@
 PODS:
-  - MapboxCommon (21.2.1)
-  - MapboxCoreMaps (10.4.2):
-    - MapboxCommon (~> 21.2)
-  - MapboxCoreNavigation (2.4.1):
-    - MapboxDirections (~> 2.4)
+  - MapboxCommon (21.3.0)
+  - MapboxCoreMaps (10.5.1):
+    - MapboxCommon (~> 21.3)
+  - MapboxCoreNavigation (2.5.0):
+    - MapboxDirections (~> 2.5.0)
     - MapboxMobileEvents (~> 1.0)
-    - MapboxNavigationNative (< 95.0.0, >= 94.0.3)
-  - MapboxDirections (2.4.0):
+    - MapboxNavigationNative (~> 101.0)
+  - MapboxDirections (2.5.0):
     - Polyline (~> 5.0)
     - Turf (~> 2.0)
-  - MapboxMaps (10.4.3):
-    - MapboxCommon (= 21.2.1)
-    - MapboxCoreMaps (= 10.4.2)
+  - MapboxMaps (10.5.0):
+    - MapboxCommon (= 21.3.0)
+    - MapboxCoreMaps (= 10.5.1)
     - MapboxMobileEvents (= 1.0.7)
     - Turf (~> 2.0)
   - MapboxMobileEvents (1.0.7)
-  - MapboxNavigation (2.4.1):
-    - MapboxCoreNavigation (= 2.4.1)
-    - MapboxMaps (< 11.0.0, >= 10.4.3)
+  - MapboxNavigation (2.5.0):
+    - MapboxCoreNavigation (= 2.5.0)
+    - MapboxMaps (~> 10.5)
     - MapboxMobileEvents (~> 1.0)
     - MapboxSpeech (~> 2.0)
     - Solar-dev (~> 3.0)
-  - MapboxNavigationNative (94.0.3):
-    - MapboxCommon (~> 21.2)
+  - MapboxNavigationNative (101.0.0):
+    - MapboxCommon (~> 21.3)
   - MapboxSpeech (2.0.0)
   - Polyline (5.0.2)
   - Solar-dev (3.0.1)
   - Turf (2.4.0)
 
 DEPENDENCIES:
-  - MapboxCoreNavigation (~> 2.0)
-  - MapboxNavigation (~> 2.0)
+  - MapboxCoreNavigation (~> 2.5.0)
+  - MapboxNavigation (~> 2.5.0)
 
 SPEC REPOS:
   trunk:
@@ -48,19 +48,19 @@ SPEC REPOS:
     - Turf
 
 SPEC CHECKSUMS:
-  MapboxCommon: e518bf4e496722343c77177943cf3c11efe3fc9e
-  MapboxCoreMaps: 227b33943eb5b257fdebc56474007e214981f43d
-  MapboxCoreNavigation: 8add6f6c30c2415b7d95c32f3f1eef33bb38d00d
-  MapboxDirections: c3fd015787ff85b6bcfba7b12156d75fa74121b1
-  MapboxMaps: d692e7a2ddce3f59eb2b881733c1a8ca18d1d2eb
+  MapboxCommon: a336e40b53e3fda5c419fe093c9c40aff4f4dd2b
+  MapboxCoreMaps: f0c995b043323571ec46d7d9e496390982f6509d
+  MapboxCoreNavigation: 5714160c82d691003513012012f9fb380a7b0d82
+  MapboxDirections: a5ca101fe80e5f39dfe38e4d5131572890d797c4
+  MapboxMaps: e85375aa3d6bea94bf9c0221aa59f35ee0b29f29
   MapboxMobileEvents: f7f3e8daeb4b83688ae62a4172dce79169a97233
-  MapboxNavigation: 8669fe8aa67d5da1b84afc21a120812b4d8f3f21
-  MapboxNavigationNative: 145551b74e5dab196b6b11adc366d9dce529c5d3
+  MapboxNavigation: 49619e04350a460bc8b54874e52e3a4abc417d7c
+  MapboxNavigationNative: 2616c3107613454b3bedf1e54798e42e318d875c
   MapboxSpeech: e4ed02984444b6373374c72c369edaf045cc490c
   Polyline: fce41d72e1146c41c6d081f7656827226f643dff
   Solar-dev: 4612dc9878b9fed2667d23b327f1d4e54e16e8d0
   Turf: 60b93cfdc62758526bc7bf1ef191a829aeb9694d
 
-PODFILE CHECKSUM: ade747cd70b06f12dd4076e55177eb029b4813b0
+PODFILE CHECKSUM: 9c788579cac8b5b8c8533651cb073a6c4f442049
 
 COCOAPODS: 1.11.3


### PR DESCRIPTION
This Pr is to update the Example to the latest MapboxNavigation [v2.5.0](https://github.com/mapbox/mapbox-navigation-ios/releases/tag/v2.5.0)