### PR TITLE
Update examples to Mapbox Navigation `v2.6.0`.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -3,8 +3,8 @@ install! 'cocoapods', :warn_for_unused_master_specs_repo => false
 platform :ios, '11.0'
 use_frameworks!
 
-pod 'MapboxCoreNavigation', '~> 2.5.0'
-pod 'MapboxNavigation', '~> 2.5.0'
+pod 'MapboxCoreNavigation', '~> 2.6.0'
+pod 'MapboxNavigation', '~> 2.6.0'
 
 target 'Navigation-Examples' do
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,36 +1,36 @@
 PODS:
-  - MapboxCommon (21.3.0)
-  - MapboxCoreMaps (10.5.1):
-    - MapboxCommon (~> 21.3)
-  - MapboxCoreNavigation (2.5.1):
-    - MapboxDirections (~> 2.5.0)
+  - MapboxCommon (22.0.0)
+  - MapboxCoreMaps (10.6.0):
+    - MapboxCommon (~> 22.0)
+  - MapboxCoreNavigation (2.6.0):
+    - MapboxDirections (~> 2.6)
     - MapboxMobileEvents (~> 1.0)
-    - MapboxNavigationNative (< 102.0.0, >= 101.0.1)
-  - MapboxDirections (2.5.0):
+    - MapboxNavigationNative (~> 106.0)
+  - MapboxDirections (2.6.0):
     - Polyline (~> 5.0)
+    - Turf (~> 2.4)
+  - MapboxMaps (10.6.0):
+    - MapboxCommon (= 22.0.0)
+    - MapboxCoreMaps (= 10.6.0)
+    - MapboxMobileEvents (= 1.0.8)
     - Turf (~> 2.0)
-  - MapboxMaps (10.5.0):
-    - MapboxCommon (= 21.3.0)
-    - MapboxCoreMaps (= 10.5.1)
-    - MapboxMobileEvents (= 1.0.7)
-    - Turf (~> 2.0)
-  - MapboxMobileEvents (1.0.7)
-  - MapboxNavigation (2.5.1):
-    - MapboxCoreNavigation (= 2.5.1)
-    - MapboxMaps (~> 10.5)
+  - MapboxMobileEvents (1.0.8)
+  - MapboxNavigation (2.6.0):
+    - MapboxCoreNavigation (= 2.6.0)
+    - MapboxMaps (~> 10.6)
     - MapboxMobileEvents (~> 1.0)
     - MapboxSpeech (~> 2.0)
     - Solar-dev (~> 3.0)
-  - MapboxNavigationNative (101.0.1):
-    - MapboxCommon (~> 21.3)
-  - MapboxSpeech (2.0.0)
+  - MapboxNavigationNative (106.0.0):
+    - MapboxCommon (~> 22.0)
+  - MapboxSpeech (2.0.1)
   - Polyline (5.0.2)
   - Solar-dev (3.0.1)
   - Turf (2.4.0)
 
 DEPENDENCIES:
-  - MapboxCoreNavigation (~> 2.5.0)
-  - MapboxNavigation (~> 2.5.0)
+  - MapboxCoreNavigation (~> 2.6.0)
+  - MapboxNavigation (~> 2.6.0)
 
 SPEC REPOS:
   trunk:
@@ -48,19 +48,19 @@ SPEC REPOS:
     - Turf
 
 SPEC CHECKSUMS:
-  MapboxCommon: a336e40b53e3fda5c419fe093c9c40aff4f4dd2b
-  MapboxCoreMaps: f0c995b043323571ec46d7d9e496390982f6509d
-  MapboxCoreNavigation: dac1bf2a8805c1e3a74928600c144a3339adf578
-  MapboxDirections: a5ca101fe80e5f39dfe38e4d5131572890d797c4
-  MapboxMaps: e85375aa3d6bea94bf9c0221aa59f35ee0b29f29
-  MapboxMobileEvents: f7f3e8daeb4b83688ae62a4172dce79169a97233
-  MapboxNavigation: 1f184e88f68c15e6626e6fb97d023d1499fc34a7
-  MapboxNavigationNative: 059e1ec9ee335896b9b3186a93a881bf31a70bb7
-  MapboxSpeech: e4ed02984444b6373374c72c369edaf045cc490c
+  MapboxCommon: 8b10731406d2e4472d52ae6ec3679e6e5c4bd55e
+  MapboxCoreMaps: 2019935caed7e56be1417ff70d3ad0c0cbf0264e
+  MapboxCoreNavigation: b2c6fb963d434e04c2609967b1c573d30f6f6ee0
+  MapboxDirections: 4a51348c02146bd246ce67c3e3d06e809003fbba
+  MapboxMaps: e078cc1343a0513174869a5e16ae9a18d3977252
+  MapboxMobileEvents: febdd92835daa258ca1c1faad0821c0b3394ef40
+  MapboxNavigation: 8092769e6a1450be497cca0dc79cf188884f683c
+  MapboxNavigationNative: ea019c7a8e4c6a2776d9fe11963085095d17b14a
+  MapboxSpeech: fb9129e1ca7cc2dd465397d2aea1f5f510de260e
   Polyline: fce41d72e1146c41c6d081f7656827226f643dff
   Solar-dev: 4612dc9878b9fed2667d23b327f1d4e54e16e8d0
   Turf: 60b93cfdc62758526bc7bf1ef191a829aeb9694d
 
-PODFILE CHECKSUM: 9c788579cac8b5b8c8533651cb073a6c4f442049
+PODFILE CHECKSUM: f1c747048a6fdea1d3e8814dacc4705ec7a2a180
 
 COCOAPODS: 1.11.3


### PR DESCRIPTION
Update examples to Mapbox Navigation `v2.6.0`.