### PR TITLE
Update the styled UI example with traitCollection for UI components.

### DIFF
--- a/Navigation-Examples/Examples/Styled-UI-Elements.swift
+++ b/Navigation-Examples/Examples/Styled-UI-Elements.swift
@@ -70,50 +70,54 @@ class CustomDayStyle: DayStyle {
     
     override func apply() {
         super.apply()
-        ArrivalTimeLabel.appearance().textColor = lightGrayColor
-        BottomBannerView.appearance().backgroundColor = secondaryBackgroundColor
-        Button.appearance().textColor = #colorLiteral(red: 0.9842069745, green: 0.9843751788, blue: 0.9841964841, alpha: 1)
-        CancelButton.appearance().tintColor = lightGrayColor
-        DistanceLabel.appearance(whenContainedInInstancesOf: [InstructionsBannerView.self]).unitTextColor = secondaryLabelColor
-        DistanceLabel.appearance(whenContainedInInstancesOf: [InstructionsBannerView.self]).valueTextColor = primaryLabelColor
-        DistanceLabel.appearance(whenContainedInInstancesOf: [StepInstructionsView.self]).unitTextColor = lightGrayColor
-        DistanceLabel.appearance(whenContainedInInstancesOf: [StepInstructionsView.self]).valueTextColor = darkGrayColor
-        DistanceRemainingLabel.appearance().textColor = lightGrayColor
-        DismissButton.appearance().textColor = darkGrayColor
-        FloatingButton.appearance().backgroundColor = #colorLiteral(red: 0.9999960065, green: 1, blue: 1, alpha: 1)
-        FloatingButton.appearance().tintColor = blueColor
-        InstructionsBannerView.appearance().backgroundColor = backgroundColor
-        LanesView.appearance().backgroundColor = darkBackgroundColor
-        LaneView.appearance().primaryColor = #colorLiteral(red: 0.9842069745, green: 0.9843751788, blue: 0.9841964841, alpha: 1)
-        ManeuverView.appearance().backgroundColor = backgroundColor
-        ManeuverView.appearance(whenContainedInInstancesOf: [InstructionsBannerView.self]).primaryColor = #colorLiteral(red: 0.9842069745, green: 0.9843751788, blue: 0.9841964841, alpha: 1)
-        ManeuverView.appearance(whenContainedInInstancesOf: [InstructionsBannerView.self]).secondaryColor = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 0.5)
-        ManeuverView.appearance(whenContainedInInstancesOf: [NextBannerView.self]).primaryColor = #colorLiteral(red: 0.9842069745, green: 0.9843751788, blue: 0.9841964841, alpha: 1)
-        ManeuverView.appearance(whenContainedInInstancesOf: [NextBannerView.self]).secondaryColor = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 0.5)
-        ManeuverView.appearance(whenContainedInInstancesOf: [StepInstructionsView.self]).primaryColor = darkGrayColor
-        ManeuverView.appearance(whenContainedInInstancesOf: [StepInstructionsView.self]).secondaryColor = lightGrayColor
-        NextBannerView.appearance().backgroundColor = backgroundColor
-        NextInstructionLabel.appearance().textColor = #colorLiteral(red: 0.9842069745, green: 0.9843751788, blue: 0.9841964841, alpha: 1)
-        NavigationMapView.appearance().tintColor = blueColor
-        NavigationMapView.appearance().routeCasingColor = #colorLiteral(red: 0.1968861222, green: 0.4148176908, blue: 0.8596113324, alpha: 1)
-        NavigationMapView.appearance().trafficHeavyColor = #colorLiteral(red: 0.9995597005, green: 0, blue: 0, alpha: 1)
-        NavigationMapView.appearance().trafficLowColor = blueColor
-        NavigationMapView.appearance().trafficModerateColor = #colorLiteral(red: 1, green: 0.6184511781, blue: 0, alpha: 1)
-        NavigationMapView.appearance().trafficSevereColor = #colorLiteral(red: 0.7458544374, green: 0.0006075350102, blue: 0, alpha: 1)
-        NavigationMapView.appearance().trafficUnknownColor = blueColor
+        
+        let traitCollection = UIScreen.main.traitCollection
+        ArrivalTimeLabel.appearance(for: traitCollection).textColor = lightGrayColor
+        BottomBannerView.appearance(for: traitCollection).backgroundColor = secondaryBackgroundColor
+        BottomPaddingView.appearance(for: traitCollection).backgroundColor = secondaryBackgroundColor
+        Button.appearance(for: traitCollection).textColor = #colorLiteral(red: 0.9842069745, green: 0.9843751788, blue: 0.9841964841, alpha: 1)
+        CancelButton.appearance(for: traitCollection).tintColor = lightGrayColor
+        DistanceLabel.appearance(for: traitCollection, whenContainedInInstancesOf: [InstructionsBannerView.self]).unitTextColor = secondaryLabelColor
+        DistanceLabel.appearance(for: traitCollection, whenContainedInInstancesOf: [InstructionsBannerView.self]).valueTextColor = primaryLabelColor
+        DistanceLabel.appearance(for: traitCollection, whenContainedInInstancesOf: [StepInstructionsView.self]).unitTextColor = lightGrayColor
+        DistanceLabel.appearance(for: traitCollection, whenContainedInInstancesOf: [StepInstructionsView.self]).valueTextColor = darkGrayColor
+        DistanceRemainingLabel.appearance(for: traitCollection).textColor = lightGrayColor
+        DismissButton.appearance(for: traitCollection).textColor = darkGrayColor
+        FloatingButton.appearance(for: traitCollection).backgroundColor = #colorLiteral(red: 0.9999960065, green: 1, blue: 1, alpha: 1)
+        FloatingButton.appearance(for: traitCollection).tintColor = blueColor
+        TopBannerView.appearance(for: traitCollection).backgroundColor = backgroundColor
+        InstructionsBannerView.appearance(for: traitCollection).backgroundColor = backgroundColor
+        LanesView.appearance(for: traitCollection).backgroundColor = darkBackgroundColor
+        LaneView.appearance(for: traitCollection).primaryColor = #colorLiteral(red: 0.9842069745, green: 0.9843751788, blue: 0.9841964841, alpha: 1)
+        ManeuverView.appearance(for: traitCollection).backgroundColor = backgroundColor
+        ManeuverView.appearance(for: traitCollection, whenContainedInInstancesOf: [InstructionsBannerView.self]).primaryColor = #colorLiteral(red: 0.9842069745, green: 0.9843751788, blue: 0.9841964841, alpha: 1)
+        ManeuverView.appearance(for: traitCollection, whenContainedInInstancesOf: [InstructionsBannerView.self]).secondaryColor = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 0.5)
+        ManeuverView.appearance(for: traitCollection, whenContainedInInstancesOf: [NextBannerView.self]).primaryColor = #colorLiteral(red: 0.9842069745, green: 0.9843751788, blue: 0.9841964841, alpha: 1)
+        ManeuverView.appearance(for: traitCollection, whenContainedInInstancesOf: [NextBannerView.self]).secondaryColor = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 0.5)
+        ManeuverView.appearance(for: traitCollection, whenContainedInInstancesOf: [StepInstructionsView.self]).primaryColor = darkGrayColor
+        ManeuverView.appearance(for: traitCollection, whenContainedInInstancesOf: [StepInstructionsView.self]).secondaryColor = lightGrayColor
+        NextBannerView.appearance(for: traitCollection).backgroundColor = backgroundColor
+        NextInstructionLabel.appearance(for: traitCollection).textColor = #colorLiteral(red: 0.9842069745, green: 0.9843751788, blue: 0.9841964841, alpha: 1)
+        NavigationMapView.appearance(for: traitCollection).tintColor = blueColor
+        NavigationMapView.appearance(for: traitCollection).routeCasingColor = #colorLiteral(red: 0.1968861222, green: 0.4148176908, blue: 0.8596113324, alpha: 1)
+        NavigationMapView.appearance(for: traitCollection).trafficHeavyColor = #colorLiteral(red: 0.9995597005, green: 0, blue: 0, alpha: 1)
+        NavigationMapView.appearance(for: traitCollection).trafficLowColor = blueColor
+        NavigationMapView.appearance(for: traitCollection).trafficModerateColor = #colorLiteral(red: 1, green: 0.6184511781, blue: 0, alpha: 1)
+        NavigationMapView.appearance(for: traitCollection).trafficSevereColor = #colorLiteral(red: 0.7458544374, green: 0.0006075350102, blue: 0, alpha: 1)
+        NavigationMapView.appearance(for: traitCollection).trafficUnknownColor = blueColor
         // Customize the color that appears on the traversed section of a route
-        NavigationMapView.appearance().traversedRouteColor = #colorLiteral(red: 0.8039215803, green: 0.8039215803, blue: 0.8039215803, alpha: 0.5)
-        PrimaryLabel.appearance(whenContainedInInstancesOf: [InstructionsBannerView.self]).normalTextColor = primaryLabelColor
-        PrimaryLabel.appearance(whenContainedInInstancesOf: [StepInstructionsView.self]).normalTextColor = darkGrayColor
-        ResumeButton.appearance().backgroundColor = secondaryBackgroundColor
-        ResumeButton.appearance().tintColor = blueColor
-        SecondaryLabel.appearance(whenContainedInInstancesOf: [InstructionsBannerView.self]).normalTextColor = secondaryLabelColor
-        SecondaryLabel.appearance(whenContainedInInstancesOf: [StepInstructionsView.self]).normalTextColor = darkGrayColor
-        TimeRemainingLabel.appearance().textColor = lightGrayColor
-        TimeRemainingLabel.appearance().trafficLowColor = darkBackgroundColor
-        TimeRemainingLabel.appearance().trafficUnknownColor = darkGrayColor
-        WayNameLabel.appearance().normalTextColor = blueColor
-        WayNameView.appearance().backgroundColor = secondaryBackgroundColor
+        NavigationMapView.appearance(for: traitCollection).traversedRouteColor = #colorLiteral(red: 0.8039215803, green: 0.8039215803, blue: 0.8039215803, alpha: 0.5)
+        PrimaryLabel.appearance(for: traitCollection, whenContainedInInstancesOf: [InstructionsBannerView.self]).normalTextColor = primaryLabelColor
+        PrimaryLabel.appearance(for: traitCollection, whenContainedInInstancesOf: [StepInstructionsView.self]).normalTextColor = darkGrayColor
+        ResumeButton.appearance(for: traitCollection).backgroundColor = secondaryBackgroundColor
+        ResumeButton.appearance(for: traitCollection).tintColor = blueColor
+        SecondaryLabel.appearance(for: traitCollection, whenContainedInInstancesOf: [InstructionsBannerView.self]).normalTextColor = secondaryLabelColor
+        SecondaryLabel.appearance(for: traitCollection, whenContainedInInstancesOf: [StepInstructionsView.self]).normalTextColor = darkGrayColor
+        TimeRemainingLabel.appearance(for: traitCollection).textColor = lightGrayColor
+        TimeRemainingLabel.appearance(for: traitCollection).trafficLowColor = darkBackgroundColor
+        TimeRemainingLabel.appearance(for: traitCollection).trafficUnknownColor = darkGrayColor
+        WayNameLabel.appearance(for: traitCollection).normalTextColor = blueColor
+        WayNameView.appearance(for: traitCollection).backgroundColor = secondaryBackgroundColor
     }
 }
 
@@ -136,13 +140,16 @@ class CustomNightStyle: NightStyle {
     
     override func apply() {
         super.apply()
-        DistanceRemainingLabel.appearance().normalTextColor = primaryTextColor
-        BottomBannerView.appearance().backgroundColor = secondaryBackgroundColor
-        FloatingButton.appearance().backgroundColor = #colorLiteral(red: 0.1434620917, green: 0.1434366405, blue: 0.1819391251, alpha: 0.9037466989)
-        TimeRemainingLabel.appearance().textColor = primaryTextColor
-        TimeRemainingLabel.appearance().trafficLowColor = primaryTextColor
-        TimeRemainingLabel.appearance().trafficUnknownColor = primaryTextColor
-        ResumeButton.appearance().backgroundColor = #colorLiteral(red: 0.1434620917, green: 0.1434366405, blue: 0.1819391251, alpha: 0.9037466989)
-        ResumeButton.appearance().tintColor = blueColor
+        
+        let traitCollection = UIScreen.main.traitCollection
+        DistanceRemainingLabel.appearance(for: traitCollection).normalTextColor = primaryTextColor
+        BottomBannerView.appearance(for: traitCollection).backgroundColor = secondaryBackgroundColor
+        BottomPaddingView.appearance(for: traitCollection).backgroundColor = secondaryBackgroundColor
+        FloatingButton.appearance(for: traitCollection).backgroundColor = #colorLiteral(red: 0.1434620917, green: 0.1434366405, blue: 0.1819391251, alpha: 0.9037466989)
+        TimeRemainingLabel.appearance(for: traitCollection).textColor = primaryTextColor
+        TimeRemainingLabel.appearance(for: traitCollection).trafficLowColor = primaryTextColor
+        TimeRemainingLabel.appearance(for: traitCollection).trafficUnknownColor = primaryTextColor
+        ResumeButton.appearance(for: traitCollection).backgroundColor = #colorLiteral(red: 0.1434620917, green: 0.1434366405, blue: 0.1819391251, alpha: 0.9037466989)
+        ResumeButton.appearance(for: traitCollection).tintColor = blueColor
     }
 }


### PR DESCRIPTION
This Pr is to fix #179 by updating the `Styled-UI-Elements` example to add `traitCollection` for the appearance of UI components in customized styling.

For Day:
![Day](https://user-images.githubusercontent.com/48976398/185481821-6e99d531-ada4-464a-bca1-e441cecc3cc1.png)

For Night:
![Night](https://user-images.githubusercontent.com/48976398/185481843-da7e1b5f-bfad-419d-80b6-7b2fa41a67a5.png)

