### PR TITLE
Add the update version workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,14 @@
 version: 2.1
 
+commands:
+  install-mbx-ci:
+    steps:
+      - run:
+          name: "Install MBX CI"
+          command: |
+            curl -Ls https://mapbox-release-engineering.s3.amazonaws.com/mbx-ci/latest/mbx-ci-darwin-amd64 > /usr/local/bin/mbx-ci
+            chmod 755 /usr/local/bin/mbx-ci
+
 step-library:
   - &install-swiftlint
        run:
@@ -43,7 +52,46 @@ jobs:
           name: DocsCode
           command: xcodebuild -workspace Navigation-Examples.xcworkspace -scheme DocsCode -sdk iphonesimulator -configuration Release -destination "platform=iOS Simulator,name=<< parameters.device >>,OS=<< parameters.ios >>" clean build
 
+  update-version-job:
+    parameters:
+      xcode:
+        type: string
+        default: "13.4.1"
+    macos:
+      xcode: << parameters.xcode >>
+    steps:
+      - checkout
+      - run:
+          name: Prepare .netrc file
+          command: |
+            echo "machine api.mapbox.com" >> ~/.netrc
+            echo "login mapbox" >> ~/.netrc
+            echo "password $SDK_REGISTRY_TOKEN" >> ~/.netrc
+            chmod 600 ~/.netrc
+      - install-mbx-ci
+      - run:
+          name: Add GitHub to known hosts
+          command: |
+            for ip in $(dig @8.8.8.8 github.com +short); do ssh-keyscan github.com,$ip; ssh-keyscan $ip; done 2>/dev/null >> ~/.ssh/known_hosts
+      - run:
+          name: Update Dependencies
+          command: pod update
+      - run:
+          name: Publish update
+          command: |
+            export GITHUB_WRITER_TOKEN=$(mbx-ci github writer public token)
+            git remote set-url origin "https://x-access-token:$GITHUB_WRITER_TOKEN@github.com/mapbox/mapbox-navigation-ios-examples"
+            git config --global user.email no-reply@mapbox.com && git config --global user.name mapbox-ci
+            VERSION=$( echo << pipeline.git.branch >> | sed 's/^trigger-update-version-//' )
+            ./Scripts/update-version.sh $VERSION
+
 workflows:
+  update-version-workflow:
+    jobs:
+      - update-version-job:
+          filters:
+            branches:
+              only: /^trigger-update-version-.*/
   workflow:
     jobs:
       - build-job:

--- a/Scripts/update-version.sh
+++ b/Scripts/update-version.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -e
+set -o pipefail
+set -u
+
+VERSION=$1
+
+BASE_BRANCH_NAME="main"
+BRANCH_NAME="update-version-${VERSION}"
+git checkout -b $BRANCH_NAME
+git add .
+git commit -m "Update version ${VERSION}"
+git push origin $BRANCH_NAME
+
+brew install gh
+GITHUB_TOKEN=$GITHUB_WRITER_TOKEN gh pr create \
+    --title "Navigation v${VERSION}" \
+    --body "Update to Mapbox Navigation ${VERSION}" \
+    --base $BASE_BRANCH_NAME \
+    --head $BRANCH_NAME


### PR DESCRIPTION
This workflow will be used by the Release train app in the **Update version in examples** stage.

update-version-workflow runs **pod update** and the **scripts/update-version.sh** script. It's necessary to execute this script on the Circle CI because the Release train app instance running on the Linux machine and the script needs MacOS.

You can read more about this step in the Release train app doc.