### PR TITLE
Update documentation to mention MapboxRoutingProvider as the main route provider instead of Directions Client

### DIFF
--- a/DocsCode/NavigationTutorial/NavigationTutorialViewController.swift
+++ b/DocsCode/NavigationTutorial/NavigationTutorialViewController.swift
@@ -8,10 +8,10 @@ import Turf
 
 class ViewController: UIViewController {
     // #-code-snippet: navigation vc-variables-swift
+    private let routeProvider = MapboxRoutingProvider()
     var navigationMapView: NavigationMapView!
     var navigationViewController: NavigationViewController!
-    var routeOptions: NavigationRouteOptions?
-    var routeResponse: RouteResponse?
+    var indexedRouteResponse: IndexedRouteResponse?
     var startButton: UIButton!
     // #-end-code-snippet: navigation vc-variables-swift
 
@@ -87,10 +87,9 @@ class ViewController: UIViewController {
     // #-code-snippet: navigation tapped-button-swift
     // Present the navigation view controller when the start button is tapped
     @objc func tappedButton(sender: UIButton) {
-        guard let routeResponse, let navigationRouteOptions = routeOptions else { return }
-        
-        navigationViewController = NavigationViewController(for: routeResponse, routeIndex: 0,
-                                                                routeOptions: navigationRouteOptions)
+        guard let indexedRouteResponse else { return }
+
+        navigationViewController = NavigationViewController(for: indexedRouteResponse)
         navigationViewController.modalPresentationStyle = .fullScreen
         
         present(navigationViewController, animated: true, completion: nil)
@@ -108,17 +107,16 @@ class ViewController: UIViewController {
         let routeOptions = NavigationRouteOptions(waypoints: [origin, destination], profileIdentifier: .automobileAvoidingTraffic)
 
         // Generate the route object and draw it on the map
-        Directions.shared.calculate(routeOptions) { [weak self] (session, result) in
+        routeProvider.calculateRoutes(options: routeOptions) { [weak self] result in
             switch result {
             case .failure(let error):
                 print(error.localizedDescription)
-            case .success(let response):
-                guard let route = response.routes?.first, let strongSelf = self else {
+            case .success(let indexedRouteResponse):
+                guard let route = indexedRouteResponse.currentRoute, let strongSelf = self else {
                     return
                 }
                 
-                strongSelf.routeResponse = response
-                strongSelf.routeOptions = routeOptions
+                strongSelf.indexedRouteResponse = indexedRouteResponse
                 
                 // Show the start button
                 strongSelf.startButton?.isHidden = false

--- a/DocsCode/NavigationTutorial/NavigationTutorialViewController.swift
+++ b/DocsCode/NavigationTutorial/NavigationTutorialViewController.swift
@@ -87,7 +87,7 @@ class ViewController: UIViewController {
     // #-code-snippet: navigation tapped-button-swift
     // Present the navigation view controller when the start button is tapped
     @objc func tappedButton(sender: UIButton) {
-        guard let routeResponse = routeResponse, let navigationRouteOptions = routeOptions else { return }
+        guard let routeResponse, let navigationRouteOptions = routeOptions else { return }
         
         navigationViewController = NavigationViewController(for: routeResponse, routeIndex: 0,
                                                                 routeOptions: navigationRouteOptions)

--- a/DocsCode/NavigationTutorial/NavigationTutorialViewController.swift
+++ b/DocsCode/NavigationTutorial/NavigationTutorialViewController.swift
@@ -8,7 +8,7 @@ import Turf
 
 class ViewController: UIViewController {
     // #-code-snippet: navigation vc-variables-swift
-    private let routeProvider = MapboxRoutingProvider()
+    private let routingProvider = MapboxRoutingProvider()
     var navigationMapView: NavigationMapView!
     var navigationViewController: NavigationViewController!
     var indexedRouteResponse: IndexedRouteResponse?
@@ -107,7 +107,7 @@ class ViewController: UIViewController {
         let routeOptions = NavigationRouteOptions(waypoints: [origin, destination], profileIdentifier: .automobileAvoidingTraffic)
 
         // Generate the route object and draw it on the map
-        routeProvider.calculateRoutes(options: routeOptions) { [weak self] result in
+        routingProvider.calculateRoutes(options: routeOptions) { [weak self] result in
             switch result {
             case .failure(let error):
                 print(error.localizedDescription)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,7 @@ GEM
       rexml (~> 3.2.4)
 
 PLATFORMS
+  arm64-darwin-21
   arm64-darwin-22
   x86_64-darwin-21
 
@@ -94,4 +95,4 @@ DEPENDENCIES
   cocoapods (~> 1.13)
 
 BUNDLED WITH
-   2.3.26
+   2.4.13

--- a/Navigation-Examples.xcodeproj/project.pbxproj
+++ b/Navigation-Examples.xcodeproj/project.pbxproj
@@ -350,7 +350,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0920;
-				LastUpgradeCheck = 1220;
+				LastUpgradeCheck = 1530;
 				ORGANIZATIONNAME = Mapbox;
 				TargetAttributes = {
 					961FC4FD22E0265300C72877 = {

--- a/Navigation-Examples.xcodeproj/xcshareddata/xcschemes/DocsCode.xcscheme
+++ b/Navigation-Examples.xcodeproj/xcshareddata/xcschemes/DocsCode.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1530"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "961FC4FD22E0265300C72877"
+               BuildableName = "DocsCode.app"
+               BlueprintName = "DocsCode"
+               ReferencedContainer = "container:Navigation-Examples.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "961FC4FD22E0265300C72877"
+            BuildableName = "DocsCode.app"
+            BlueprintName = "DocsCode"
+            ReferencedContainer = "container:Navigation-Examples.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "961FC4FD22E0265300C72877"
+            BuildableName = "DocsCode.app"
+            BlueprintName = "DocsCode"
+            ReferencedContainer = "container:Navigation-Examples.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Navigation-Examples.xcodeproj/xcshareddata/xcschemes/Navigation-Examples.xcscheme
+++ b/Navigation-Examples.xcodeproj/xcshareddata/xcschemes/Navigation-Examples.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1530"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C58FB8551FE899B800C4B491"
+               BuildableName = "Navigation-Examples.app"
+               BlueprintName = "Navigation-Examples"
+               ReferencedContainer = "container:Navigation-Examples.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C58FB8551FE899B800C4B491"
+            BuildableName = "Navigation-Examples.app"
+            BlueprintName = "Navigation-Examples"
+            ReferencedContainer = "container:Navigation-Examples.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C58FB8551FE899B800C4B491"
+            BuildableName = "Navigation-Examples.app"
+            BlueprintName = "Navigation-Examples"
+            ReferencedContainer = "container:Navigation-Examples.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Navigation-Examples/Examples/Advanced.swift
+++ b/Navigation-Examples/Examples/Advanced.swift
@@ -12,6 +12,7 @@ import MapboxDirections
 import MapboxMaps
 
 class AdvancedViewController: UIViewController, NavigationMapViewDelegate, NavigationViewControllerDelegate {
+    private let routeProvider = MapboxRoutingProvider()
     
     var navigationMapView: NavigationMapView! {
         didSet {
@@ -31,33 +32,29 @@ class AdvancedViewController: UIViewController, NavigationMapViewDelegate, Navig
             ])
         }
     }
-
-    var currentRouteIndex = 0 {
+    
+    var indexedRouteResponse: IndexedRouteResponse? {
         didSet {
+            guard indexedRouteResponse?.currentRoute != nil else {
+                navigationMapView.removeRoutes()
+                navigationMapView.removeWaypoints()
+                return
+            }
             showCurrentRoute()
         }
     }
+
     var currentRoute: Route? {
-        return routes?[currentRouteIndex]
+        return indexedRouteResponse?.currentRoute
     }
-    
+
     var routes: [Route]? {
-        return routeResponse?.routes
+        return indexedRouteResponse?.routeResponse.routes
     }
-    
-    var routeResponse: RouteResponse? {
-        didSet {
-            guard currentRoute != nil else {
-                navigationMapView.removeRoutes()
-                return
-            }
-            currentRouteIndex = 0
-        }
-    }
-    
+
     func showCurrentRoute() {
         guard let currentRoute = currentRoute else { return }
-        
+
         var routes = [currentRoute]
         routes.append(contentsOf: self.routes!.filter {
             $0 != currentRoute
@@ -111,16 +108,16 @@ class AdvancedViewController: UIViewController, NavigationMapViewDelegate, Navig
     }
 
     @objc func tappedButton(sender: UIButton) {
-        guard let routeResponse = routeResponse else { return }
+        guard let indexedRouteResponse else { return }
+
         // For demonstration purposes, simulate locations if the Simulate Navigation option is on.
-        let indexedRouteResponse = IndexedRouteResponse(routeResponse: routeResponse, routeIndex: currentRouteIndex)
         let navigationService = MapboxNavigationService(indexedRouteResponse: indexedRouteResponse,
                                                         customRoutingProvider: NavigationSettings.shared.directions,
                                                         credentials: NavigationSettings.shared.directions.credentials,
                                                         simulating: simulationIsEnabled ? .always : .onPoorGPS)
         
+        // Replace default `NavigationMapView` instance with instance that is used in preview mode.
         let navigationOptions = NavigationOptions(navigationService: navigationService,
-                                                  // Replace default `NavigationMapView` instance with instance that is used in preview mode.
                                                   navigationMapView: navigationMapView)
         
         let navigationViewController = NavigationViewController(for: indexedRouteResponse,
@@ -177,27 +174,26 @@ class AdvancedViewController: UIViewController, NavigationMapViewDelegate, Navig
         
         let navigationRouteOptions = NavigationRouteOptions(waypoints: [userWaypoint, destinationWaypoint])
         
-        Directions.shared.calculate(navigationRouteOptions) { [weak self] (_, result) in
+        routeProvider.calculateRoutes(options: navigationRouteOptions) { [weak self] result in
             switch result {
             case .failure(let error):
                 print(error.localizedDescription)
-            case .success(let response):
+            case .success(let indexedRouteResponse):
                 guard let self = self else { return }
 
-                self.routeResponse = response
+                self.indexedRouteResponse = indexedRouteResponse
                 self.startButton?.isHidden = false
-                if let routes = self.routes,
-                   let currentRoute = self.currentRoute {
-                    self.navigationMapView.show(routes)
-                    self.navigationMapView.showWaypoints(on: currentRoute)
-                }
             }
         }
     }
     
     // Delegate method called when the user selects a route
     func navigationMapView(_ mapView: NavigationMapView, didSelect route: Route) {
-        self.currentRouteIndex = self.routes?.firstIndex(of: route) ?? 0
+        guard let routes = indexedRouteResponse?.routeResponse.routes else { return }
+
+        let currentRouteIndex = routes.firstIndex(of: route) ?? 0
+        indexedRouteResponse?.routeIndex = currentRouteIndex
+        showCurrentRoute()
     }
     
     func navigationViewControllerDidDismiss(_ navigationViewController: NavigationViewController, byCanceling canceled: Bool) {

--- a/Navigation-Examples/Examples/Advanced.swift
+++ b/Navigation-Examples/Examples/Advanced.swift
@@ -12,7 +12,7 @@ import MapboxDirections
 import MapboxMaps
 
 class AdvancedViewController: UIViewController, NavigationMapViewDelegate, NavigationViewControllerDelegate {
-    private let routeProvider = MapboxRoutingProvider()
+    private let routingProvider = MapboxRoutingProvider()
     
     var navigationMapView: NavigationMapView! {
         didSet {
@@ -112,7 +112,7 @@ class AdvancedViewController: UIViewController, NavigationMapViewDelegate, Navig
 
         // For demonstration purposes, simulate locations if the Simulate Navigation option is on.
         let navigationService = MapboxNavigationService(indexedRouteResponse: indexedRouteResponse,
-                                                        customRoutingProvider: NavigationSettings.shared.directions,
+                                                        customRoutingProvider: routingProvider,
                                                         credentials: NavigationSettings.shared.directions.credentials,
                                                         simulating: simulationIsEnabled ? .always : .onPoorGPS)
         
@@ -174,7 +174,7 @@ class AdvancedViewController: UIViewController, NavigationMapViewDelegate, Navig
         
         let navigationRouteOptions = NavigationRouteOptions(waypoints: [userWaypoint, destinationWaypoint])
         
-        routeProvider.calculateRoutes(options: navigationRouteOptions) { [weak self] result in
+        routingProvider.calculateRoutes(options: navigationRouteOptions) { [weak self] result in
             switch result {
             case .failure(let error):
                 print(error.localizedDescription)

--- a/Navigation-Examples/Examples/Advanced.swift
+++ b/Navigation-Examples/Examples/Advanced.swift
@@ -179,7 +179,7 @@ class AdvancedViewController: UIViewController, NavigationMapViewDelegate, Navig
             case .failure(let error):
                 print(error.localizedDescription)
             case .success(let indexedRouteResponse):
-                guard let self = self else { return }
+                guard let self else { return }
 
                 self.indexedRouteResponse = indexedRouteResponse
                 self.startButton?.isHidden = false

--- a/Navigation-Examples/Examples/Basic.swift
+++ b/Navigation-Examples/Examples/Basic.swift
@@ -12,7 +12,7 @@ import MapboxNavigation
 import MapboxDirections
 
 class BasicViewController: UIViewController {
-    private let routeProvider = MapboxRoutingProvider()
+    private let routingProvider = MapboxRoutingProvider()
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -21,19 +21,19 @@ class BasicViewController: UIViewController {
         let destination = CLLocationCoordinate2DMake(37.76556957793795, -122.42409811526268)
         let options = NavigationRouteOptions(coordinates: [origin, destination])
 
-        routeProvider.calculateRoutes(options: options) { [weak self] result in
+        routingProvider.calculateRoutes(options: options) { [weak self] result in
             switch result {
             case .failure(let error):
                 print(error.localizedDescription)
             case .success(let indexedRouteResponse):
-                guard let strongSelf = self else {
+                guard let self else {
                     return
                 }
                 
                 // For demonstration purposes, simulate locations if the Simulate Navigation option is on.
                 // Since first route is retrieved from response `routeIndex` is set to 0.
                 let navigationService = MapboxNavigationService(indexedRouteResponse: indexedRouteResponse,
-                                                                customRoutingProvider: NavigationSettings.shared.directions,
+                                                                customRoutingProvider: self.routingProvider,
                                                                 credentials: NavigationSettings.shared.directions.credentials,
                                                                 simulating: simulationIsEnabled ? .always : .onPoorGPS)
                 
@@ -44,7 +44,7 @@ class BasicViewController: UIViewController {
                 // Render part of the route that has been traversed with full transparency, to give the illusion of a disappearing route.
                 navigationViewController.routeLineTracksTraversal = true
                 
-                strongSelf.present(navigationViewController, animated: true, completion: nil)
+                self.present(navigationViewController, animated: true, completion: nil)
             }
         }
     }

--- a/Navigation-Examples/Examples/Basic.swift
+++ b/Navigation-Examples/Examples/Basic.swift
@@ -12,25 +12,26 @@ import MapboxNavigation
 import MapboxDirections
 
 class BasicViewController: UIViewController {
+    private let routeProvider = MapboxRoutingProvider()
+
     override func viewDidLoad() {
         super.viewDidLoad()
         
         let origin = CLLocationCoordinate2DMake(37.77440680146262, -122.43539772352648)
         let destination = CLLocationCoordinate2DMake(37.76556957793795, -122.42409811526268)
         let options = NavigationRouteOptions(coordinates: [origin, destination])
-        
-        Directions.shared.calculate(options) { [weak self] (_, result) in
+
+        routeProvider.calculateRoutes(options: options) { [weak self] result in
             switch result {
             case .failure(let error):
                 print(error.localizedDescription)
-            case .success(let response):
+            case .success(let indexedRouteResponse):
                 guard let strongSelf = self else {
                     return
                 }
                 
                 // For demonstration purposes, simulate locations if the Simulate Navigation option is on.
                 // Since first route is retrieved from response `routeIndex` is set to 0.
-                let indexedRouteResponse = IndexedRouteResponse(routeResponse: response, routeIndex: 0)
                 let navigationService = MapboxNavigationService(indexedRouteResponse: indexedRouteResponse,
                                                                 customRoutingProvider: NavigationSettings.shared.directions,
                                                                 credentials: NavigationSettings.shared.directions.credentials,

--- a/Navigation-Examples/Examples/Beta-Query-Parameters.swift
+++ b/Navigation-Examples/Examples/Beta-Query-Parameters.swift
@@ -158,7 +158,7 @@ class BetaQueryViewController: UIViewController, NavigationMapViewDelegate, Navi
             case .success(let indexedRouteResponse):
                     guard let routes = indexedRouteResponse.routeResponse.routes,
                       let currentRoute = indexedRouteResponse.currentRoute,
-                      let self = self else { return }
+                      let self else { return }
 
                 self.indexedRouteResponse = indexedRouteResponse
                 self.startButton?.isHidden = false

--- a/Navigation-Examples/Examples/Beta-Query-Parameters.swift
+++ b/Navigation-Examples/Examples/Beta-Query-Parameters.swift
@@ -12,7 +12,7 @@ import MapboxDirections
 import MapboxMaps
 
 class BetaQueryViewController: UIViewController, NavigationMapViewDelegate, NavigationViewControllerDelegate {
-    private let routeProvider = MapboxRoutingProvider()
+    private let routingProvider = MapboxRoutingProvider()
     
     var navigationMapView: NavigationMapView!
     
@@ -120,7 +120,7 @@ class BetaQueryViewController: UIViewController, NavigationMapViewDelegate, Navi
 
         // For demonstration purposes, simulate locations if the Simulate Navigation option is on.
         let navigationService = MapboxNavigationService(indexedRouteResponse: indexedRouteResponse,
-                                                        customRoutingProvider: NavigationSettings.shared.directions,
+                                                        customRoutingProvider: routingProvider,
                                                         credentials: NavigationSettings.shared.directions.credentials,
                                                         simulating: simulationIsEnabled ? .always : .onPoorGPS)
         let navigationOptions = NavigationOptions(navigationService: navigationService)
@@ -151,7 +151,7 @@ class BetaQueryViewController: UIViewController, NavigationMapViewDelegate, Navi
         let destinationWaypoint = Waypoint(coordinate: destination)
         let navigationRouteOptions = MopedRouteOptions(waypoints: [userWaypoint, destinationWaypoint], departTime: dateTextField.text!)
                 
-        routeProvider.calculateRoutes(options: navigationRouteOptions) { [weak self] result in
+        routingProvider.calculateRoutes(options: navigationRouteOptions) { [weak self] result in
             switch result {
             case .failure(let error):
                 print(error.localizedDescription)

--- a/Navigation-Examples/Examples/Building-Extrusion.swift
+++ b/Navigation-Examples/Examples/Building-Extrusion.swift
@@ -12,7 +12,7 @@ import MapboxDirections
 import MapboxMaps
 
 class BuildingExtrusionViewController: UIViewController, NavigationMapViewDelegate, NavigationViewControllerDelegate, UIGestureRecognizerDelegate {
-    private let routeProvider = MapboxRoutingProvider()
+    private let routingProvider = MapboxRoutingProvider()
     
     typealias ActionHandler = (UIAlertAction) -> Void
     
@@ -133,7 +133,7 @@ class BuildingExtrusionViewController: UIViewController, NavigationMapViewDelega
         }
 
         let navigationService = MapboxNavigationService(indexedRouteResponse: indexedRouteResponse,
-                                                        customRoutingProvider: NavigationSettings.shared.directions,
+                                                        customRoutingProvider: routingProvider,
                                                         credentials: NavigationSettings.shared.directions.credentials,
                                                         simulating: simulationIsEnabled ? .always : .onPoorGPS)
         let navigationOptions = NavigationOptions(navigationService: navigationService)
@@ -206,7 +206,7 @@ class BuildingExtrusionViewController: UIViewController, NavigationMapViewDelega
 
     func requestRoute() {
         let navigationRouteOptions = NavigationRouteOptions(waypoints: waypoints)
-        routeProvider.calculateRoutes(options: navigationRouteOptions) { [weak self] result in
+        routingProvider.calculateRoutes(options: navigationRouteOptions) { [weak self] result in
             switch result {
             case .failure(let error):
                 self?.presentAlert(message: error.localizedDescription)

--- a/Navigation-Examples/Examples/Custom-Destination-Marker.swift
+++ b/Navigation-Examples/Examples/Custom-Destination-Marker.swift
@@ -13,7 +13,7 @@ import MapboxDirections
 import MapboxMaps
 
 class CustomDestinationMarkerController: UIViewController {
-    private let routeProvider = MapboxRoutingProvider()
+    private let routingProvider = MapboxRoutingProvider()
     
     var navigationMapView: NavigationMapView!
     var startNavigationButton: UIButton!
@@ -67,7 +67,7 @@ class CustomDestinationMarkerController: UIViewController {
     
     @objc func tappedButton(_ sender: UIButton) {
         let navigationService = MapboxNavigationService(indexedRouteResponse: indexedRouteResponse,
-                                                        customRoutingProvider: NavigationSettings.shared.directions,
+                                                        customRoutingProvider: routingProvider,
                                                         credentials: NavigationSettings.shared.directions.credentials,
                                                         simulating: simulationIsEnabled ? .always : .onPoorGPS)
         let navigationOptions = NavigationOptions(navigationService: navigationService)
@@ -86,7 +86,7 @@ class CustomDestinationMarkerController: UIViewController {
         
         navigationMapView.mapView.mapboxMap.setCamera(to: CameraOptions(center: destination, zoom: 13.0))
         
-        routeProvider.calculateRoutes(options: navigationRouteOptions) { [weak self] result in
+        routingProvider.calculateRoutes(options: navigationRouteOptions) { [weak self] result in
             switch result {
             case .failure(let error):
                 NSLog("Error occured: \(error.localizedDescription).")

--- a/Navigation-Examples/Examples/Custom-Destination-Marker.swift
+++ b/Navigation-Examples/Examples/Custom-Destination-Marker.swift
@@ -93,7 +93,7 @@ class CustomDestinationMarkerController: UIViewController {
             case .success(let indexedRouteResponse):
                 guard let routes = indexedRouteResponse.routeResponse.routes,
                       let currentRoute = indexedRouteResponse.currentRoute,
-                      let self = self else { return }
+                      let self else { return }
 
                 self.indexedRouteResponse = indexedRouteResponse
                 self.startNavigationButton?.isHidden = false

--- a/Navigation-Examples/Examples/Custom-Destination-Marker.swift
+++ b/Navigation-Examples/Examples/Custom-Destination-Marker.swift
@@ -13,11 +13,12 @@ import MapboxDirections
 import MapboxMaps
 
 class CustomDestinationMarkerController: UIViewController {
+    private let routeProvider = MapboxRoutingProvider()
     
     var navigationMapView: NavigationMapView!
     var startNavigationButton: UIButton!
-    var routeResponse: RouteResponse!
-    
+    var indexedRouteResponse: IndexedRouteResponse!
+
     // MARK: - UIViewController lifecycle methods
     
     override func viewDidLoad() {
@@ -65,7 +66,6 @@ class CustomDestinationMarkerController: UIViewController {
     }
     
     @objc func tappedButton(_ sender: UIButton) {
-        let indexedRouteResponse = IndexedRouteResponse(routeResponse: routeResponse, routeIndex: 0)
         let navigationService = MapboxNavigationService(indexedRouteResponse: indexedRouteResponse,
                                                         customRoutingProvider: NavigationSettings.shared.directions,
                                                         credentials: NavigationSettings.shared.directions.credentials,
@@ -86,16 +86,16 @@ class CustomDestinationMarkerController: UIViewController {
         
         navigationMapView.mapView.mapboxMap.setCamera(to: CameraOptions(center: destination, zoom: 13.0))
         
-        Directions.shared.calculate(navigationRouteOptions) { [weak self] (_, result) in
+        routeProvider.calculateRoutes(options: navigationRouteOptions) { [weak self] result in
             switch result {
             case .failure(let error):
                 NSLog("Error occured: \(error.localizedDescription).")
-            case .success(let response):
-                guard let routes = response.routes,
-                      let currentRoute = routes.first,
+            case .success(let indexedRouteResponse):
+                guard let routes = indexedRouteResponse.routeResponse.routes,
+                      let currentRoute = indexedRouteResponse.currentRoute,
                       let self = self else { return }
 
-                self.routeResponse = response
+                self.indexedRouteResponse = indexedRouteResponse
                 self.startNavigationButton?.isHidden = false
                 
                 self.navigationMapView.show(routes)

--- a/Navigation-Examples/Examples/Custom-RoutingProvider.swift
+++ b/Navigation-Examples/Examples/Custom-RoutingProvider.swift
@@ -57,7 +57,7 @@ class CustomRoutingProviderViewController: UIViewController {
 
 class CustomProvider: RoutingProvider {
     // This can encapsulate any route building engine we need. For simplicity let's use `MapboxRoutingProvider`.
-    let routeProvider = MapboxRoutingProvider()
+    let routingProvider = MapboxRoutingProvider()
     
     // We can also modify the options used to calculate a route.
     func applyOptionsModification(_ options: DirectionsOptions) {
@@ -95,14 +95,14 @@ class CustomProvider: RoutingProvider {
         applyOptionsModification(options)
         
         // Using `MapboxRoutingProvider` also illustrates cases when we need to modify just a part of the route, or dynamically edit `RouteOptions` for each reroute.
-        return routeProvider.calculateRoutes(options: options,
+        return routingProvider.calculateRoutes(options: options,
                                                completionHandler: completionHandler)
     }
     
     func calculateRoutes(options: MatchOptions, completionHandler: @escaping Directions.MatchCompletionHandler) -> NavigationProviderRequest? {
         applyOptionsModification(options)
         
-        return routeProvider.calculateRoutes(options: options,
+        return routingProvider.calculateRoutes(options: options,
                                                completionHandler: { [weak self] (session, result) in
             switch result {
             case .failure(let error):
@@ -121,7 +121,7 @@ class CustomProvider: RoutingProvider {
 
     func calculateRoutes(options: MapboxDirections.RouteOptions,
                          completionHandler: @escaping IndexedRouteResponseCompletionHandler) -> MapboxCoreNavigation.NavigationProviderRequest? {
-        routeProvider.calculateRoutes(options: options, completionHandler: completionHandler)
+        routingProvider.calculateRoutes(options: options, completionHandler: completionHandler)
     }
     
     // Let's make our custom routing provider prevent route refreshes.
@@ -145,7 +145,7 @@ class CustomProvider: RoutingProvider {
                       currentRouteShapeIndex: Int,
                       currentLegShapeIndex: Int,
                       completionHandler: @escaping MapboxDirections.Directions.RouteCompletionHandler) -> MapboxCoreNavigation.NavigationProviderRequest? {
-        routeProvider.refreshRoute(indexedRouteResponse: indexedRouteResponse,
+        routingProvider.refreshRoute(indexedRouteResponse: indexedRouteResponse,
                                      fromLegAtIndex: startLegIndex,
                                      currentRouteShapeIndex: currentRouteShapeIndex,
                                      currentLegShapeIndex: currentLegShapeIndex,

--- a/Navigation-Examples/Examples/Custom-Server.swift
+++ b/Navigation-Examples/Examples/Custom-Server.swift
@@ -31,7 +31,7 @@ class CustomServerViewController: UIViewController {
             case .failure(let error):
                 print(error.localizedDescription)
             case .success(let indexedRouteResponse):
-                guard let self = self else {
+                guard let self else {
                     return
                 }
                 

--- a/Navigation-Examples/Examples/Custom-Server.swift
+++ b/Navigation-Examples/Examples/Custom-Server.swift
@@ -13,6 +13,7 @@ import MapboxNavigation
 import MapboxDirections
 
 class CustomServerViewController: UIViewController {
+    private let routeProvider = MapboxRoutingProvider()
     
     let routeOptions = NavigationRouteOptions(coordinates: [
         CLLocationCoordinate2DMake(37.77440680146262, -122.43539772352648),
@@ -25,17 +26,16 @@ class CustomServerViewController: UIViewController {
         super.viewDidLoad()
         
         let routeOptions = self.routeOptions
-        Directions.shared.calculate(routeOptions) { [weak self] (_, result) in
+        routeProvider.calculateRoutes(options: routeOptions) { [weak self] result in
             switch result {
             case .failure(let error):
                 print(error.localizedDescription)
-            case .success(let response):
+            case .success(let indexedRouteResponse):
                 guard let strongSelf = self else {
                     return
                 }
                 
                 // For demonstration purposes, simulate locations if the Simulate Navigation option is on.
-                let indexedRouteResponse = IndexedRouteResponse(routeResponse: response, routeIndex: 0)
                 let navigationService = MapboxNavigationService(indexedRouteResponse: indexedRouteResponse,
                                                                 customRoutingProvider: NavigationSettings.shared.directions,
                                                                 credentials: NavigationSettings.shared.directions.credentials,
@@ -61,12 +61,12 @@ extension CustomServerViewController: NavigationViewControllerDelegate {
         
         // Here, we are simulating a custom server.
         let routeOptions = NavigationRouteOptions(waypoints: [Waypoint(location: location), self.routeOptions.waypoints.last!])
-        Directions.shared.calculate(routeOptions) { [weak self] (_, result) in
+        routeProvider.calculateRoutes(options: routeOptions) { [weak self] result in
             switch result {
             case .failure(let error):
                 print(error.localizedDescription)
             case .success(let response):
-                guard let routeShape = response.routes?.first?.shape else {
+                guard let routeShape = response.currentRoute?.shape else {
                     return
                 }
                 

--- a/Navigation-Examples/Examples/Custom-Server.swift
+++ b/Navigation-Examples/Examples/Custom-Server.swift
@@ -13,7 +13,7 @@ import MapboxNavigation
 import MapboxDirections
 
 class CustomServerViewController: UIViewController {
-    private let routeProvider = MapboxRoutingProvider()
+    private let routingProvider = MapboxRoutingProvider()
     
     let routeOptions = NavigationRouteOptions(coordinates: [
         CLLocationCoordinate2DMake(37.77440680146262, -122.43539772352648),
@@ -26,27 +26,27 @@ class CustomServerViewController: UIViewController {
         super.viewDidLoad()
         
         let routeOptions = self.routeOptions
-        routeProvider.calculateRoutes(options: routeOptions) { [weak self] result in
+        routingProvider.calculateRoutes(options: routeOptions) { [weak self] result in
             switch result {
             case .failure(let error):
                 print(error.localizedDescription)
             case .success(let indexedRouteResponse):
-                guard let strongSelf = self else {
+                guard let self = self else {
                     return
                 }
                 
                 // For demonstration purposes, simulate locations if the Simulate Navigation option is on.
                 let navigationService = MapboxNavigationService(indexedRouteResponse: indexedRouteResponse,
-                                                                customRoutingProvider: NavigationSettings.shared.directions,
+                                                                customRoutingProvider: self.routingProvider,
                                                                 credentials: NavigationSettings.shared.directions.credentials,
                                                                 simulating: simulationIsEnabled ? .always : .onPoorGPS)
                 let navigationOptions = NavigationOptions(navigationService: navigationService)
-                strongSelf.navigationViewController = NavigationViewController(for: indexedRouteResponse,
-                                                                               navigationOptions: navigationOptions)
-                strongSelf.navigationViewController?.modalPresentationStyle = .fullScreen
-                strongSelf.navigationViewController?.delegate = strongSelf
-                
-                strongSelf.present(strongSelf.navigationViewController!, animated: true, completion: nil)
+                self.navigationViewController = NavigationViewController(for: indexedRouteResponse,
+                                                                           navigationOptions: navigationOptions)
+                self.navigationViewController?.modalPresentationStyle = .fullScreen
+                self.navigationViewController?.delegate = self
+
+                self.present(self.navigationViewController!, animated: true, completion: nil)
             }
         }
     }
@@ -61,7 +61,7 @@ extension CustomServerViewController: NavigationViewControllerDelegate {
         
         // Here, we are simulating a custom server.
         let routeOptions = NavigationRouteOptions(waypoints: [Waypoint(location: location), self.routeOptions.waypoints.last!])
-        routeProvider.calculateRoutes(options: routeOptions) { [weak self] result in
+        routingProvider.calculateRoutes(options: routeOptions) { [weak self] result in
             switch result {
             case .failure(let error):
                 print(error.localizedDescription)

--- a/Navigation-Examples/Examples/Custom-User-Location.swift
+++ b/Navigation-Examples/Examples/Custom-User-Location.swift
@@ -14,7 +14,7 @@ import MapboxMaps
 class CustomUserLocationViewController: UIViewController, NavigationMapViewDelegate, NavigationViewControllerDelegate, UIGestureRecognizerDelegate {
     typealias ActionHandler = (UIAlertAction) -> Void
 
-    private let routeProvider = MapboxRoutingProvider()
+    private let routingProvider = MapboxRoutingProvider()
     
     var navigationMapView: NavigationMapView! {
         didSet {
@@ -139,7 +139,7 @@ class CustomUserLocationViewController: UIViewController, NavigationMapViewDeleg
         waypoints.insert(userWaypoint, at: 0)
         let navigationRouteOptions = NavigationRouteOptions(waypoints: waypoints)
         
-        routeProvider.calculateRoutes(options: navigationRouteOptions) { [weak self] result in
+        routingProvider.calculateRoutes(options: navigationRouteOptions) { [weak self] result in
             switch result {
             case .failure(let error):
                 print(error.localizedDescription)
@@ -269,7 +269,7 @@ class CustomUserLocationViewController: UIViewController, NavigationMapViewDeleg
         guard let indexedRouteResponse else { return }
 
         let navigationService = MapboxNavigationService(indexedRouteResponse: indexedRouteResponse,
-                                                        customRoutingProvider: NavigationSettings.shared.directions,
+                                                        customRoutingProvider: routingProvider,
                                                         credentials: NavigationSettings.shared.directions.credentials,
                                                         simulating: simulationIsEnabled ? .always : .onPoorGPS)
         let navigationOptions = NavigationOptions(navigationService: navigationService)

--- a/Navigation-Examples/Examples/Custom-Voice-Controller.swift
+++ b/Navigation-Examples/Examples/Custom-Voice-Controller.swift
@@ -14,6 +14,7 @@ import MapboxSpeech
 import AVFoundation
 
 class CustomVoiceControllerUI: UIViewController {
+    private let routeProvider = MapboxRoutingProvider()
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -22,7 +23,7 @@ class CustomVoiceControllerUI: UIViewController {
         let destination = CLLocationCoordinate2DMake(37.76556957793795, -122.42409811526268)
         let routeOptions = NavigationRouteOptions(coordinates: [origin, destination])
         
-        Directions.shared.calculate(routeOptions) { [weak self] (_, result) in
+        routeProvider.calculateRoutes(options: routeOptions) { [weak self] result in
             switch result {
             case .failure(let error):
                 print(error.localizedDescription)
@@ -32,10 +33,9 @@ class CustomVoiceControllerUI: UIViewController {
         }
     }
 
-    func presentNavigationWithCustomVoiceController(response: RouteResponse) {
+    func presentNavigationWithCustomVoiceController(response: IndexedRouteResponse) {
         // For demonstration purposes, simulate locations if the Simulate Navigation option is on.
-        let indexedRouteResponse = IndexedRouteResponse(routeResponse: response, routeIndex: 0)
-        let navigationService = MapboxNavigationService(indexedRouteResponse: indexedRouteResponse,
+        let navigationService = MapboxNavigationService(indexedRouteResponse: response,
                                                         customRoutingProvider: NavigationSettings.shared.directions,
                                                         credentials: NavigationSettings.shared.directions.credentials,
                                                         simulating: simulationIsEnabled ? .always : .onPoorGPS)
@@ -54,7 +54,7 @@ class CustomVoiceControllerUI: UIViewController {
                                                   voiceController: routeVoiceController)
 
         // Create `NavigationViewController` with the custom `NavigationOptions`.
-        let navigationViewController = NavigationViewController(for: indexedRouteResponse,
+        let navigationViewController = NavigationViewController(for: response,
                                                                 navigationOptions: navigationOptions)
         navigationViewController.modalPresentationStyle = .fullScreen
 

--- a/Navigation-Examples/Examples/Custom-Voice-Controller.swift
+++ b/Navigation-Examples/Examples/Custom-Voice-Controller.swift
@@ -14,7 +14,7 @@ import MapboxSpeech
 import AVFoundation
 
 class CustomVoiceControllerUI: UIViewController {
-    private let routeProvider = MapboxRoutingProvider()
+    private let routingProvider = MapboxRoutingProvider()
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -23,7 +23,7 @@ class CustomVoiceControllerUI: UIViewController {
         let destination = CLLocationCoordinate2DMake(37.76556957793795, -122.42409811526268)
         let routeOptions = NavigationRouteOptions(coordinates: [origin, destination])
         
-        routeProvider.calculateRoutes(options: routeOptions) { [weak self] result in
+        routingProvider.calculateRoutes(options: routeOptions) { [weak self] result in
             switch result {
             case .failure(let error):
                 print(error.localizedDescription)
@@ -36,7 +36,7 @@ class CustomVoiceControllerUI: UIViewController {
     func presentNavigationWithCustomVoiceController(response: IndexedRouteResponse) {
         // For demonstration purposes, simulate locations if the Simulate Navigation option is on.
         let navigationService = MapboxNavigationService(indexedRouteResponse: response,
-                                                        customRoutingProvider: NavigationSettings.shared.directions,
+                                                        customRoutingProvider: routingProvider,
                                                         credentials: NavigationSettings.shared.directions.credentials,
                                                         simulating: simulationIsEnabled ? .always : .onPoorGPS)
 

--- a/Navigation-Examples/Examples/Custom-Waypoints.swift
+++ b/Navigation-Examples/Examples/Custom-Waypoints.swift
@@ -13,7 +13,7 @@ import MapboxMaps
 import Turf
 
 class CustomWaypointsViewController: UIViewController {
-    private let routeProvider = MapboxRoutingProvider()
+    private let routingProvider = MapboxRoutingProvider()
     
     var navigationMapView: NavigationMapView!
 
@@ -80,7 +80,7 @@ class CustomWaypointsViewController: UIViewController {
         guard let indexedRouteResponse else { return }
         // For demonstration purposes, simulate locations if the Simulate Navigation option is on.
         let navigationService = MapboxNavigationService(indexedRouteResponse: indexedRouteResponse,
-                                                        customRoutingProvider: NavigationSettings.shared.directions,
+                                                        customRoutingProvider: routingProvider,
                                                         credentials: NavigationSettings.shared.directions.credentials,
                                                         simulating: simulationIsEnabled ? .always : .onPoorGPS)
         let navigationOptions = NavigationOptions(navigationService: navigationService)
@@ -100,7 +100,7 @@ class CustomWaypointsViewController: UIViewController {
         let cameraOptions = CameraOptions(center: origin, zoom: 13.0)
         self.navigationMapView.mapView.mapboxMap.setCamera(to: cameraOptions)
         
-        routeProvider.calculateRoutes(options: navigationRouteOptions) { [weak self] result in
+        routingProvider.calculateRoutes(options: navigationRouteOptions) { [weak self] result in
             switch result {
             case .failure(let error):
                 print(error.localizedDescription)

--- a/Navigation-Examples/Examples/Custom-Waypoints.swift
+++ b/Navigation-Examples/Examples/Custom-Waypoints.swift
@@ -106,7 +106,7 @@ class CustomWaypointsViewController: UIViewController {
                 print(error.localizedDescription)
             case .success(let indexedRouteResponse):
                 guard indexedRouteResponse.currentRoute != nil,
-                      let self = self else { return }
+                      let self else { return }
 
                 self.indexedRouteResponse = indexedRouteResponse
                 self.startButton?.isHidden = false

--- a/Navigation-Examples/Examples/CustomBars/CustomBarsViewController.swift
+++ b/Navigation-Examples/Examples/CustomBars/CustomBarsViewController.swift
@@ -26,7 +26,7 @@ class CustomBarsViewController: UIViewController {
             case .failure(let error):
                 print(error.localizedDescription)
             case .success(let indexedRouteResponse):
-                guard let self = self else {
+                guard let self else {
                     return
                 }
                 

--- a/Navigation-Examples/Examples/CustomBars/CustomBarsViewController.swift
+++ b/Navigation-Examples/Examples/CustomBars/CustomBarsViewController.swift
@@ -12,6 +12,8 @@ import MapboxNavigation
 import MapboxDirections
 
 class CustomBarsViewController: UIViewController {
+    private let routeProvider = MapboxRoutingProvider()
+
     override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -19,17 +21,16 @@ class CustomBarsViewController: UIViewController {
         let destination = CLLocationCoordinate2DMake(37.76556957793795, -122.42409811526268)
         let routeOptions = NavigationRouteOptions(coordinates: [origin, destination])
         
-        Directions.shared.calculate(routeOptions) { [weak self] (_, result) in
+        routeProvider.calculateRoutes(options: routeOptions) { [weak self] result in
             switch result {
             case .failure(let error):
                 print(error.localizedDescription)
-            case .success(let response):
+            case .success(let indexedRouteResponse):
                 guard let strongSelf = self else {
                     return
                 }
                 
                 // For demonstration purposes, simulate locations if the Simulate Navigation option is on.
-                let indexedRouteResponse = IndexedRouteResponse(routeResponse: response, routeIndex: 0)
                 let navigationService = MapboxNavigationService(indexedRouteResponse: indexedRouteResponse,
                                                                 customRoutingProvider: NavigationSettings.shared.directions,
                                                                 credentials: NavigationSettings.shared.directions.credentials,

--- a/Navigation-Examples/Examples/CustomBars/CustomBarsViewController.swift
+++ b/Navigation-Examples/Examples/CustomBars/CustomBarsViewController.swift
@@ -12,7 +12,7 @@ import MapboxNavigation
 import MapboxDirections
 
 class CustomBarsViewController: UIViewController {
-    private let routeProvider = MapboxRoutingProvider()
+    private let routingProvider = MapboxRoutingProvider()
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -21,18 +21,18 @@ class CustomBarsViewController: UIViewController {
         let destination = CLLocationCoordinate2DMake(37.76556957793795, -122.42409811526268)
         let routeOptions = NavigationRouteOptions(coordinates: [origin, destination])
         
-        routeProvider.calculateRoutes(options: routeOptions) { [weak self] result in
+        routingProvider.calculateRoutes(options: routeOptions) { [weak self] result in
             switch result {
             case .failure(let error):
                 print(error.localizedDescription)
             case .success(let indexedRouteResponse):
-                guard let strongSelf = self else {
+                guard let self = self else {
                     return
                 }
                 
                 // For demonstration purposes, simulate locations if the Simulate Navigation option is on.
                 let navigationService = MapboxNavigationService(indexedRouteResponse: indexedRouteResponse,
-                                                                customRoutingProvider: NavigationSettings.shared.directions,
+                                                                customRoutingProvider: self.routingProvider,
                                                                 credentials: NavigationSettings.shared.directions.credentials,
                                                                 simulating: simulationIsEnabled ? .always : .onPoorGPS)
                 
@@ -63,7 +63,7 @@ class CustomBarsViewController: UIViewController {
 
                 navigationViewController.modalPresentationStyle = .fullScreen
                 
-                strongSelf.present(navigationViewController, animated: true, completion: nil)
+                self.present(navigationViewController, animated: true, completion: nil)
                 navigationViewController.floatingButtons = []
                 navigationViewController.showsSpeedLimits = false
             }

--- a/Navigation-Examples/Examples/CustomSegue/Navigation-From-Segue.swift
+++ b/Navigation-Examples/Examples/CustomSegue/Navigation-From-Segue.swift
@@ -11,7 +11,7 @@ import MapboxCoreNavigation
 import MapboxDirections
 
 class SegueViewController: UIViewController {
-    private let routeProvider = MapboxRoutingProvider()
+    private let routingProvider = MapboxRoutingProvider()
     
     var indexedRouteResponse: IndexedRouteResponse!
 
@@ -28,7 +28,7 @@ class SegueViewController: UIViewController {
         let destination = CLLocationCoordinate2DMake(37.76556957793795, -122.42409811526268)
         let navigationRouteOptions = NavigationRouteOptions(coordinates: [origin, destination])
         
-        routeProvider.calculateRoutes(options: navigationRouteOptions) { [weak self] result in
+        routingProvider.calculateRoutes(options: navigationRouteOptions) { [weak self] result in
             switch result {
             case .failure(let error):
                 NSLog("Error occured: \(error.localizedDescription).")
@@ -38,7 +38,7 @@ class SegueViewController: UIViewController {
                 self.indexedRouteResponse = indexedRouteResponse
 
                 let navigationService = MapboxNavigationService(indexedRouteResponse: indexedRouteResponse,
-                                                                customRoutingProvider: NavigationSettings.shared.directions,
+                                                                customRoutingProvider: self.routingProvider,
                                                                 credentials: NavigationSettings.shared.directions.credentials,
                                                                 simulating: simulationIsEnabled ? .always : .onPoorGPS)
                 self.navigationOptions = NavigationOptions(navigationService: navigationService)

--- a/Navigation-Examples/Examples/CustomSegue/Navigation-From-Segue.swift
+++ b/Navigation-Examples/Examples/CustomSegue/Navigation-From-Segue.swift
@@ -11,9 +11,10 @@ import MapboxCoreNavigation
 import MapboxDirections
 
 class SegueViewController: UIViewController {
+    private let routeProvider = MapboxRoutingProvider()
     
-    var routeResponse: RouteResponse!
-    
+    var indexedRouteResponse: IndexedRouteResponse!
+
     var navigationOptions: NavigationOptions!
     
     @IBOutlet weak var presentNavigationButton: UIButton!
@@ -27,16 +28,15 @@ class SegueViewController: UIViewController {
         let destination = CLLocationCoordinate2DMake(37.76556957793795, -122.42409811526268)
         let navigationRouteOptions = NavigationRouteOptions(coordinates: [origin, destination])
         
-        Directions.shared.calculate(navigationRouteOptions) { [weak self] (_, result) in
+        routeProvider.calculateRoutes(options: navigationRouteOptions) { [weak self] result in
             switch result {
             case .failure(let error):
                 NSLog("Error occured: \(error.localizedDescription).")
-            case .success(let response):
+            case .success(let indexedRouteResponse):
                 guard let self = self else { return }
                 
-                self.routeResponse = response
-                
-                let indexedRouteResponse = IndexedRouteResponse(routeResponse: response, routeIndex: 0)
+                self.indexedRouteResponse = indexedRouteResponse
+
                 let navigationService = MapboxNavigationService(indexedRouteResponse: indexedRouteResponse,
                                                                 customRoutingProvider: NavigationSettings.shared.directions,
                                                                 credentials: NavigationSettings.shared.directions.credentials,
@@ -59,7 +59,6 @@ class SegueViewController: UIViewController {
         switch segue.identifier ?? "" {
         case "NavigationSegue":
             if let navigationViewController = segue.destination as? NavigationViewController {
-                let indexedRouteResponse = IndexedRouteResponse(routeResponse: routeResponse, routeIndex: 0)
                 _ = navigationViewController.prepareViewLoading(indexedRouteResponse: indexedRouteResponse)
                 // `navigationOptions` property is optional.
                 navigationViewController.navigationOptions = navigationOptions

--- a/Navigation-Examples/Examples/CustomSegue/Navigation-From-Segue.swift
+++ b/Navigation-Examples/Examples/CustomSegue/Navigation-From-Segue.swift
@@ -33,7 +33,7 @@ class SegueViewController: UIViewController {
             case .failure(let error):
                 NSLog("Error occured: \(error.localizedDescription).")
             case .success(let indexedRouteResponse):
-                guard let self = self else { return }
+                guard let self else { return }
                 
                 self.indexedRouteResponse = indexedRouteResponse
 

--- a/Navigation-Examples/Examples/Embedded-Navigation.swift
+++ b/Navigation-Examples/Examples/Embedded-Navigation.swift
@@ -12,11 +12,13 @@ import MapboxDirections
 import MapboxMaps
 
 class EmbeddedExampleViewController: UIViewController {
+    private let routeProvider = MapboxRoutingProvider()
  
     @IBOutlet weak var reroutedLabel: UILabel!
     @IBOutlet weak var enableReroutes: UISwitch!
     @IBOutlet weak var container: UIView!
-    var routeResponse: RouteResponse?
+
+    var indexedRouteResponse: IndexedRouteResponse?
 
     lazy var routeOptions: NavigationRouteOptions = {
         let origin = CLLocationCoordinate2DMake(37.77440680146262, -122.43539772352648)
@@ -33,16 +35,16 @@ class EmbeddedExampleViewController: UIViewController {
     }
 
     func calculateDirections() {
-        Directions.shared.calculate(routeOptions) { [weak self] (_, result) in
+        routeProvider.calculateRoutes(options: routeOptions) { [weak self] result in
             switch result {
             case .failure(let error):
                 print(error.localizedDescription)
-            case .success(let response):
+            case .success(let indexedRouteResponse):
                 guard let strongSelf = self else {
                     return
                 }
                 
-                strongSelf.routeResponse = response
+                strongSelf.indexedRouteResponse = indexedRouteResponse
                 strongSelf.startEmbeddedNavigation()
             }
         }
@@ -60,8 +62,8 @@ class EmbeddedExampleViewController: UIViewController {
     
     func startEmbeddedNavigation() {
         // For demonstration purposes, simulate locations if the Simulate Navigation option is on.
-        guard let routeResponse = routeResponse else { return }
-        let indexedRouteResponse = IndexedRouteResponse(routeResponse: routeResponse, routeIndex: 0)
+        guard let indexedRouteResponse else { return }
+
         let navigationService = MapboxNavigationService(indexedRouteResponse: indexedRouteResponse,
                                                         customRoutingProvider: NavigationSettings.shared.directions,
                                                         credentials: NavigationSettings.shared.directions.credentials,

--- a/Navigation-Examples/Examples/Embedded-Navigation.swift
+++ b/Navigation-Examples/Examples/Embedded-Navigation.swift
@@ -12,7 +12,7 @@ import MapboxDirections
 import MapboxMaps
 
 class EmbeddedExampleViewController: UIViewController {
-    private let routeProvider = MapboxRoutingProvider()
+    private let routingProvider = MapboxRoutingProvider()
  
     @IBOutlet weak var reroutedLabel: UILabel!
     @IBOutlet weak var enableReroutes: UISwitch!
@@ -35,7 +35,7 @@ class EmbeddedExampleViewController: UIViewController {
     }
 
     func calculateDirections() {
-        routeProvider.calculateRoutes(options: routeOptions) { [weak self] result in
+        routingProvider.calculateRoutes(options: routeOptions) { [weak self] result in
             switch result {
             case .failure(let error):
                 print(error.localizedDescription)
@@ -65,7 +65,7 @@ class EmbeddedExampleViewController: UIViewController {
         guard let indexedRouteResponse else { return }
 
         let navigationService = MapboxNavigationService(indexedRouteResponse: indexedRouteResponse,
-                                                        customRoutingProvider: NavigationSettings.shared.directions,
+                                                        customRoutingProvider: routingProvider,
                                                         credentials: NavigationSettings.shared.directions.credentials,
                                                         simulating: simulationIsEnabled ? .always : .onPoorGPS)
         let navigationOptions = NavigationOptions(navigationService: navigationService)

--- a/Navigation-Examples/Examples/History-Recording.swift
+++ b/Navigation-Examples/Examples/History-Recording.swift
@@ -165,7 +165,7 @@ class HistoryRecordingViewController: UIViewController, NavigationMapViewDelegat
             case .failure(let error):
                 print(error.localizedDescription)
             case .success(let indexedRouteResponse):
-                guard let self = self, indexedRouteResponse.currentRoute != nil else { return }
+                guard let self, indexedRouteResponse.currentRoute != nil else { return }
 
                 self.indexedRouteResponse = indexedRouteResponse
                 self.startButton?.isHidden = false

--- a/Navigation-Examples/Examples/History-Recording.swift
+++ b/Navigation-Examples/Examples/History-Recording.swift
@@ -12,7 +12,7 @@ import MapboxDirections
 import MapboxMaps
 
 class HistoryRecordingViewController: UIViewController, NavigationMapViewDelegate, NavigationViewControllerDelegate {
-    private let routeProvider = MapboxRoutingProvider()
+    private let routingProvider = MapboxRoutingProvider()
 
     var navigationMapView: NavigationMapView! {
         didSet {
@@ -160,7 +160,7 @@ class HistoryRecordingViewController: UIViewController, NavigationMapViewDelegat
         
         let navigationRouteOptions = NavigationRouteOptions(waypoints: [userWaypoint, destinationWaypoint])
         
-        routeProvider.calculateRoutes(options: navigationRouteOptions) { [weak self] result in
+        routingProvider.calculateRoutes(options: navigationRouteOptions) { [weak self] result in
             switch result {
             case .failure(let error):
                 print(error.localizedDescription)
@@ -186,7 +186,7 @@ class HistoryRecordingViewController: UIViewController, NavigationMapViewDelegat
 
         // For demonstration purposes, simulate locations if the Simulate Navigation option is on.
         let navigationService = MapboxNavigationService(indexedRouteResponse: indexedRouteResponse,
-                                                        customRoutingProvider: NavigationSettings.shared.directions,
+                                                        customRoutingProvider: routingProvider,
                                                         credentials: NavigationSettings.shared.directions.credentials,
                                                         simulating: simulationIsEnabled ? .always : .onPoorGPS)
         

--- a/Navigation-Examples/Examples/NavigationCamera/Custom-Navigation-Camera.swift
+++ b/Navigation-Examples/Examples/NavigationCamera/Custom-Navigation-Camera.swift
@@ -12,7 +12,7 @@ import MapboxDirections
 import MapboxCoreNavigation
 
 class CustomNavigationCameraViewController: UIViewController {
-    private let routeProvider = MapboxRoutingProvider()
+    private let routingProvider = MapboxRoutingProvider()
     
     var navigationMapView: NavigationMapView!
     var indexedRouteResponse: IndexedRouteResponse!
@@ -71,7 +71,7 @@ class CustomNavigationCameraViewController: UIViewController {
     
     @objc func startNavigationButtonPressed(_ sender: UIButton) {
         let navigationService = MapboxNavigationService(indexedRouteResponse: indexedRouteResponse,
-                                                        customRoutingProvider: NavigationSettings.shared.directions,
+                                                        customRoutingProvider: routingProvider,
                                                         credentials: NavigationSettings.shared.directions.credentials,
                                                         simulating: simulationIsEnabled ? .always : .onPoorGPS)
         
@@ -100,7 +100,7 @@ class CustomNavigationCameraViewController: UIViewController {
         let destination = navigationMapView.mapView.mapboxMap.coordinate(for: gesture.location(in: navigationMapView.mapView))
         let navigationRouteOptions = NavigationRouteOptions(coordinates: [origin, destination])
         
-        routeProvider.calculateRoutes(options: navigationRouteOptions) { [weak self] result in
+        routingProvider.calculateRoutes(options: navigationRouteOptions) { [weak self] result in
             switch result {
             case .failure(let error):
                 NSLog("Error occured while requesting route: \(error.localizedDescription).")

--- a/Navigation-Examples/Examples/Offline-Regions.swift
+++ b/Navigation-Examples/Examples/Offline-Regions.swift
@@ -13,7 +13,7 @@ import MapboxNavigation
 import MapboxDirections
 
 class OfflineRegionsViewController: UIViewController {
-    private let routeProvider = MapboxRoutingProvider()
+    private let routingProvider = MapboxRoutingProvider()
 
     // MARK: Setup variables for Tile Management
     let styleURI: StyleURI = .streets
@@ -163,7 +163,7 @@ class OfflineRegionsViewController: UIViewController {
     
     func requestRoute() {
         guard let options = options else { return }
-        routeProvider.calculateRoutes(options: options) { [weak self] result in
+        routingProvider.calculateRoutes(options: options) { [weak self] result in
             switch result {
             case .failure(let error):
                 print("Failed to request route with error: \(error.localizedDescription)")
@@ -178,7 +178,7 @@ class OfflineRegionsViewController: UIViewController {
         guard let response = routeResponse else { return }
         let indexedRouteResponse = IndexedRouteResponse(routeResponse: response, routeIndex: routeIndex)
         let navigationService = MapboxNavigationService(indexedRouteResponse: indexedRouteResponse,
-                                                        customRoutingProvider: NavigationSettings.shared.directions,
+                                                        customRoutingProvider: routingProvider,
                                                         credentials: NavigationSettings.shared.directions.credentials,
                                                         simulating: .always)
         let navigationOptions = NavigationOptions(navigationService: navigationService)

--- a/Navigation-Examples/Examples/Offline-Regions.swift
+++ b/Navigation-Examples/Examples/Offline-Regions.swift
@@ -13,6 +13,8 @@ import MapboxNavigation
 import MapboxDirections
 
 class OfflineRegionsViewController: UIViewController {
+    private let routeProvider = MapboxRoutingProvider()
+
     // MARK: Setup variables for Tile Management
     let styleURI: StyleURI = .streets
     var region: Region?
@@ -161,13 +163,13 @@ class OfflineRegionsViewController: UIViewController {
     
     func requestRoute() {
         guard let options = options else { return }
-        Directions.shared.calculate(options) { [weak self] (_, result) in
+        routeProvider.calculateRoutes(options: options) { [weak self] result in
             switch result {
             case .failure(let error):
                 print("Failed to request route with error: \(error.localizedDescription)")
-            case .success(let response):
+            case .success(let indexedRouteResponse):
                 guard let strongSelf = self else { return }
-                strongSelf.routeResponse = response
+                strongSelf.routeResponse = indexedRouteResponse.routeResponse
             }
         }
     }

--- a/Navigation-Examples/Examples/Predictive-Caching.swift
+++ b/Navigation-Examples/Examples/Predictive-Caching.swift
@@ -11,7 +11,7 @@ import MapboxNavigation
 import MapboxDirections
 
 class PredictiveCachingViewController: UIViewController {
-    private let routeProvider = MapboxRoutingProvider()
+    private let routingProvider = MapboxRoutingProvider()
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -20,19 +20,19 @@ class PredictiveCachingViewController: UIViewController {
         let destination = CLLocationCoordinate2DMake(37.76556957793795, -122.42409811526268)
         let options = NavigationRouteOptions(coordinates: [origin, destination])
         
-        routeProvider.calculateRoutes(options: options) { [weak self] result in
+        routingProvider.calculateRoutes(options: options) { [weak self] result in
             switch result {
             case .failure(let error):
                 print(error.localizedDescription)
             case .success(let indexedRouteResponse):
-                guard let strongSelf = self else {
+                guard let self = self else {
                     return
                 }
                 
                 // For demonstration purposes, simulate locations if the Simulate Navigation option is on.
                 // Since first route is retrieved from response `routeIndex` is set to 0.
                 let navigationService = MapboxNavigationService(indexedRouteResponse: indexedRouteResponse,
-                                                                customRoutingProvider: NavigationSettings.shared.directions,
+                                                                customRoutingProvider: self.routingProvider,
                                                                 credentials: NavigationSettings.shared.directions.credentials,
                                                                 simulating: simulationIsEnabled ? .always : .onPoorGPS)
                 
@@ -58,7 +58,7 @@ class PredictiveCachingViewController: UIViewController {
                 navigationViewController.modalPresentationStyle = .fullScreen
                 navigationViewController.routeLineTracksTraversal = true
                 
-                strongSelf.present(navigationViewController, animated: true)
+                self.present(navigationViewController, animated: true)
             }
         }
     }

--- a/Navigation-Examples/Examples/Predictive-Caching.swift
+++ b/Navigation-Examples/Examples/Predictive-Caching.swift
@@ -11,6 +11,8 @@ import MapboxNavigation
 import MapboxDirections
 
 class PredictiveCachingViewController: UIViewController {
+    private let routeProvider = MapboxRoutingProvider()
+
     override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -18,19 +20,17 @@ class PredictiveCachingViewController: UIViewController {
         let destination = CLLocationCoordinate2DMake(37.76556957793795, -122.42409811526268)
         let options = NavigationRouteOptions(coordinates: [origin, destination])
         
-        Directions.shared.calculate(options) { [weak self] (_, result) in
+        routeProvider.calculateRoutes(options: options) { [weak self] result in
             switch result {
             case .failure(let error):
                 print(error.localizedDescription)
-            case .success(let response):
+            case .success(let indexedRouteResponse):
                 guard let strongSelf = self else {
                     return
                 }
                 
                 // For demonstration purposes, simulate locations if the Simulate Navigation option is on.
                 // Since first route is retrieved from response `routeIndex` is set to 0.
-
-                let indexedRouteResponse = IndexedRouteResponse(routeResponse: response, routeIndex: 0)
                 let navigationService = MapboxNavigationService(indexedRouteResponse: indexedRouteResponse,
                                                                 customRoutingProvider: NavigationSettings.shared.directions,
                                                                 credentials: NavigationSettings.shared.directions.credentials,

--- a/Navigation-Examples/Examples/Predictive-Caching.swift
+++ b/Navigation-Examples/Examples/Predictive-Caching.swift
@@ -25,7 +25,7 @@ class PredictiveCachingViewController: UIViewController {
             case .failure(let error):
                 print(error.localizedDescription)
             case .success(let indexedRouteResponse):
-                guard let self = self else {
+                guard let self else {
                     return
                 }
                 

--- a/Navigation-Examples/Examples/Route-Alerts.swift
+++ b/Navigation-Examples/Examples/Route-Alerts.swift
@@ -12,6 +12,8 @@ import MapboxDirections
 import MapboxNavigationNative
 
 class RouteAlertsViewController: UIViewController {
+    private let routeProvider = MapboxRoutingProvider()
+
     override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -19,18 +21,16 @@ class RouteAlertsViewController: UIViewController {
         let destination = CLLocationCoordinate2DMake(37.79727245401114, -122.46951395567203)
         let options = NavigationRouteOptions(coordinates: [origin, destination])
         
-        Directions.shared.calculate(options) { [weak self] (_, result) in
+        routeProvider.calculateRoutes(options: options) { [weak self] result in
             switch result {
             case .failure(let error):
                 print(error.localizedDescription)
-            case .success(let response):
+            case .success(let indexedRouteResponse):
                 guard let strongSelf = self else {
                     return
                 }
                 
                 // For demonstration purposes, simulate locations if the Simulate Navigation option is on.
-
-                let indexedRouteResponse = IndexedRouteResponse(routeResponse: response, routeIndex: 0)
                 let navigationService = MapboxNavigationService(indexedRouteResponse: indexedRouteResponse,
                                                                 customRoutingProvider: NavigationSettings.shared.directions,
                                                                 credentials: NavigationSettings.shared.directions.credentials,

--- a/Navigation-Examples/Examples/Route-Alerts.swift
+++ b/Navigation-Examples/Examples/Route-Alerts.swift
@@ -26,7 +26,7 @@ class RouteAlertsViewController: UIViewController {
             case .failure(let error):
                 print(error.localizedDescription)
             case .success(let indexedRouteResponse):
-                guard let self = self else {
+                guard let self else {
                     return
                 }
                 

--- a/Navigation-Examples/Examples/Route-Alerts.swift
+++ b/Navigation-Examples/Examples/Route-Alerts.swift
@@ -12,7 +12,7 @@ import MapboxDirections
 import MapboxNavigationNative
 
 class RouteAlertsViewController: UIViewController {
-    private let routeProvider = MapboxRoutingProvider()
+    private let routingProvider = MapboxRoutingProvider()
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -21,18 +21,18 @@ class RouteAlertsViewController: UIViewController {
         let destination = CLLocationCoordinate2DMake(37.79727245401114, -122.46951395567203)
         let options = NavigationRouteOptions(coordinates: [origin, destination])
         
-        routeProvider.calculateRoutes(options: options) { [weak self] result in
+        routingProvider.calculateRoutes(options: options) { [weak self] result in
             switch result {
             case .failure(let error):
                 print(error.localizedDescription)
             case .success(let indexedRouteResponse):
-                guard let strongSelf = self else {
+                guard let self = self else {
                     return
                 }
                 
                 // For demonstration purposes, simulate locations if the Simulate Navigation option is on.
                 let navigationService = MapboxNavigationService(indexedRouteResponse: indexedRouteResponse,
-                                                                customRoutingProvider: NavigationSettings.shared.directions,
+                                                                customRoutingProvider: self.routingProvider,
                                                                 credentials: NavigationSettings.shared.directions.credentials,
                                                                 simulating: simulationIsEnabled ? .always : .onPoorGPS)
                 
@@ -48,7 +48,7 @@ class RouteAlertsViewController: UIViewController {
                 
                 navigationViewController.modalPresentationStyle = .fullScreen
                 
-                strongSelf.present(navigationViewController, animated: true)
+                self.present(navigationViewController, animated: true)
             }
         }
     }

--- a/Navigation-Examples/Examples/Route-Lines-Styling.swift
+++ b/Navigation-Examples/Examples/Route-Lines-Styling.swift
@@ -13,7 +13,7 @@ import MapboxMaps
 import Turf
 
 class RouteLinesStylingViewController: UIViewController {
-    private let routeProvider = MapboxRoutingProvider()
+    private let routingProvider = MapboxRoutingProvider()
     
     typealias ActionHandler = (UIAlertAction) -> Void
     
@@ -118,7 +118,7 @@ class RouteLinesStylingViewController: UIViewController {
         }
 
         let navigationService = MapboxNavigationService(indexedRouteResponse: indexedRouteResponse,
-                                                        customRoutingProvider: NavigationSettings.shared.directions,
+                                                        customRoutingProvider: routingProvider,
                                                         credentials: NavigationSettings.shared.directions.credentials,
                                                         simulating: simulationIsEnabled ? .always : .onPoorGPS)
         
@@ -154,7 +154,7 @@ class RouteLinesStylingViewController: UIViewController {
         ]
         
         let navigationRouteOptions = NavigationRouteOptions(waypoints: waypoints)
-        routeProvider.calculateRoutes(options: navigationRouteOptions) { [weak self] result in
+        routingProvider.calculateRoutes(options: navigationRouteOptions) { [weak self] result in
             switch result {
             case .failure(let error):
                 NSLog("Error occured while requesting route: \(error.localizedDescription).")

--- a/Navigation-Examples/Examples/Route-Lines-Styling.swift
+++ b/Navigation-Examples/Examples/Route-Lines-Styling.swift
@@ -13,44 +13,39 @@ import MapboxMaps
 import Turf
 
 class RouteLinesStylingViewController: UIViewController {
+    private let routeProvider = MapboxRoutingProvider()
     
     typealias ActionHandler = (UIAlertAction) -> Void
     
     var navigationMapView: NavigationMapView!
-    
-    var currentRouteIndex = 0 {
+
+    var indexedRouteResponse: IndexedRouteResponse? {
         didSet {
+            guard indexedRouteResponse?.currentRoute != nil else {
+                navigationMapView.removeRoutes()
+                navigationMapView.removeWaypoints()
+                return
+            }
             showCurrentRoute()
         }
     }
 
     var currentRoute: Route? {
-        return routes?[currentRouteIndex]
+        return indexedRouteResponse?.currentRoute
     }
-    
+
     var routes: [Route]? {
-        return routeResponse?.routes
+        return indexedRouteResponse?.routeResponse.routes
     }
-    
-    var routeResponse: RouteResponse? {
-        didSet {
-            guard currentRoute != nil else {
-                navigationMapView.removeRoutes()
-                return
-            }
-            currentRouteIndex = 0
-        }
-    }
-    
+
     func showCurrentRoute() {
         guard let currentRoute = currentRoute else { return }
-        
+
         var routes = [currentRoute]
         routes.append(contentsOf: self.routes!.filter {
             $0 != currentRoute
         })
-        navigationMapView.show(routes)
-        navigationMapView.showWaypoints(on: currentRoute)
+        navigationMapView.showcase(routes)
     }
     
     // MARK: - UIViewController lifecycle methods
@@ -92,8 +87,8 @@ class RouteLinesStylingViewController: UIViewController {
                                                 message: "Select specific action to perform it", preferredStyle: .actionSheet)
         
         let startNavigation: ActionHandler = { _ in self.startNavigation() }
-        let removeRoutes: ActionHandler = { _ in self.routeResponse = nil }
-        
+        let removeRoutes: ActionHandler = { _ in self.indexedRouteResponse = nil }
+
         let actions: [(String, UIAlertAction.Style, ActionHandler?)] = [
             ("Start Navigation", .default, startNavigation),
             ("Remove Routes", .default, removeRoutes),
@@ -117,12 +112,11 @@ class RouteLinesStylingViewController: UIViewController {
     }
     
     @objc func startNavigation() {
-        guard let routeResponse = routeResponse else {
+        guard let indexedRouteResponse else {
             print("Please select at least one destination coordinate to start navigation.")
             return
         }
 
-        let indexedRouteResponse = IndexedRouteResponse(routeResponse: routeResponse, routeIndex: currentRouteIndex)
         let navigationService = MapboxNavigationService(indexedRouteResponse: indexedRouteResponse,
                                                         customRoutingProvider: NavigationSettings.shared.directions,
                                                         credentials: NavigationSettings.shared.directions.credentials,
@@ -160,17 +154,12 @@ class RouteLinesStylingViewController: UIViewController {
         ]
         
         let navigationRouteOptions = NavigationRouteOptions(waypoints: waypoints)
-        Directions.shared.calculate(navigationRouteOptions) { [weak self] (_, result) in
+        routeProvider.calculateRoutes(options: navigationRouteOptions) { [weak self] result in
             switch result {
             case .failure(let error):
                 NSLog("Error occured while requesting route: \(error.localizedDescription).")
-            case .success(let response):
-                guard let routes = response.routes else { return }
-                self?.routeResponse = response
-                self?.navigationMapView.show(routes)
-                if let currentRoute = self?.currentRoute {
-                    self?.navigationMapView.showWaypoints(on: currentRoute)
-                }
+            case .success(let indexedRouteResponse):
+                self?.indexedRouteResponse = indexedRouteResponse
             }
         }
     }
@@ -194,7 +183,11 @@ extension RouteLinesStylingViewController: NavigationMapViewDelegate {
     }
     
     func navigationMapView(_ mapView: NavigationMapView, didSelect route: Route) {
-        currentRouteIndex = routes?.firstIndex(of: route) ?? 0
+        guard let routes = indexedRouteResponse?.routeResponse.routes else { return }
+
+        let currentRouteIndex = routes.firstIndex(of: route) ?? 0
+        indexedRouteResponse?.routeIndex = currentRouteIndex
+        showCurrentRoute()
     }
     
     // It's possible to change route line shape in preview mode by adding own implementation to either

--- a/Navigation-Examples/Examples/Styled-UI-Elements.swift
+++ b/Navigation-Examples/Examples/Styled-UI-Elements.swift
@@ -12,7 +12,7 @@ import MapboxNavigation
 import MapboxDirections
 
 class CustomStyleUIElements: UIViewController {
-    private let routeProvider = MapboxRoutingProvider()
+    private let routingProvider = MapboxRoutingProvider()
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -21,18 +21,18 @@ class CustomStyleUIElements: UIViewController {
         let destination = CLLocationCoordinate2DMake(37.76556957793795, -122.42409811526268)
         let routeOptions = NavigationRouteOptions(coordinates: [origin, destination])
         
-        routeProvider.calculateRoutes(options: routeOptions) { [weak self] result in
+        routingProvider.calculateRoutes(options: routeOptions) { [weak self] result in
             switch result {
             case .failure(let error):
                 print(error.localizedDescription)
             case .success(let indexedRouteResponse):
-                guard let strongSelf = self else {
+                guard let self else {
                     return
                 }
                 
                 // For demonstration purposes, simulate locations if the Simulate Navigation option is on.
                 let navigationService = MapboxNavigationService(indexedRouteResponse: indexedRouteResponse,
-                                                                customRoutingProvider: NavigationSettings.shared.directions,
+                                                                customRoutingProvider: self.routingProvider,
                                                                 credentials: NavigationSettings.shared.directions.credentials,
                                                                 simulating: simulationIsEnabled ? .always : .onPoorGPS)
                 let navigationOptions = NavigationOptions(styles: [CustomDayStyle(), CustomNightStyle()],
@@ -43,7 +43,7 @@ class CustomStyleUIElements: UIViewController {
                 // Render part of the route that has been traversed with full transparency, to give the illusion of a disappearing route.
                 navigationViewController.routeLineTracksTraversal = true
                 
-                strongSelf.present(navigationViewController, animated: true, completion: nil)
+                self.present(navigationViewController, animated: true, completion: nil)
             }
         }
     }

--- a/Navigation-Examples/Examples/Styled-UI-Elements.swift
+++ b/Navigation-Examples/Examples/Styled-UI-Elements.swift
@@ -12,6 +12,8 @@ import MapboxNavigation
 import MapboxDirections
 
 class CustomStyleUIElements: UIViewController {
+    private let routeProvider = MapboxRoutingProvider()
+
     override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -19,17 +21,16 @@ class CustomStyleUIElements: UIViewController {
         let destination = CLLocationCoordinate2DMake(37.76556957793795, -122.42409811526268)
         let routeOptions = NavigationRouteOptions(coordinates: [origin, destination])
         
-        Directions.shared.calculate(routeOptions) { [weak self] (_, result) in
+        routeProvider.calculateRoutes(options: routeOptions) { [weak self] result in
             switch result {
             case .failure(let error):
                 print(error.localizedDescription)
-            case .success(let response):
+            case .success(let indexedRouteResponse):
                 guard let strongSelf = self else {
                     return
                 }
                 
                 // For demonstration purposes, simulate locations if the Simulate Navigation option is on.
-                let indexedRouteResponse = IndexedRouteResponse(routeResponse: response, routeIndex: 0)
                 let navigationService = MapboxNavigationService(indexedRouteResponse: indexedRouteResponse,
                                                                 customRoutingProvider: NavigationSettings.shared.directions,
                                                                 credentials: NavigationSettings.shared.directions.credentials,

--- a/Navigation-Examples/Examples/Waypoint-Arrival-Screen.swift
+++ b/Navigation-Examples/Examples/Waypoint-Arrival-Screen.swift
@@ -13,6 +13,7 @@ import MapboxDirections
 import MapboxMaps
 
 class WaypointArrivalScreenViewController: UIViewController {
+    private let routeProvider = MapboxRoutingProvider()
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -23,17 +24,16 @@ class WaypointArrivalScreenViewController: UIViewController {
         
         let routeOptions = NavigationRouteOptions(waypoints: [waypointOne, waypointTwo, waypointThree])
         
-        Directions.shared.calculate(routeOptions) { [weak self] (_, result) in
+        routeProvider.calculateRoutes(options: routeOptions) { [weak self] result in
             switch result {
             case .failure(let error):
                 print(error.localizedDescription)
-            case .success(let response):
+            case .success(let indexedRouteResponse):
                 guard let strongSelf = self else {
                     return
                 }
                 
                 // For demonstration purposes, simulate locations if the Simulate Navigation option is on.
-                let indexedRouteResponse = IndexedRouteResponse(routeResponse: response, routeIndex: 0)
                 let navigationService = MapboxNavigationService(indexedRouteResponse: indexedRouteResponse,
                                                                 customRoutingProvider: NavigationSettings.shared.directions,
                                                                 credentials: NavigationSettings.shared.directions.credentials,

--- a/Navigation-Examples/Examples/Waypoint-Arrival-Screen.swift
+++ b/Navigation-Examples/Examples/Waypoint-Arrival-Screen.swift
@@ -29,7 +29,7 @@ class WaypointArrivalScreenViewController: UIViewController {
             case .failure(let error):
                 print(error.localizedDescription)
             case .success(let indexedRouteResponse):
-                guard let self = self else {
+                guard let self else {
                     return
                 }
                 

--- a/Navigation-Examples/Examples/Waypoint-Arrival-Screen.swift
+++ b/Navigation-Examples/Examples/Waypoint-Arrival-Screen.swift
@@ -13,7 +13,7 @@ import MapboxDirections
 import MapboxMaps
 
 class WaypointArrivalScreenViewController: UIViewController {
-    private let routeProvider = MapboxRoutingProvider()
+    private let routingProvider = MapboxRoutingProvider()
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -24,27 +24,27 @@ class WaypointArrivalScreenViewController: UIViewController {
         
         let routeOptions = NavigationRouteOptions(waypoints: [waypointOne, waypointTwo, waypointThree])
         
-        routeProvider.calculateRoutes(options: routeOptions) { [weak self] result in
+        routingProvider.calculateRoutes(options: routeOptions) { [weak self] result in
             switch result {
             case .failure(let error):
                 print(error.localizedDescription)
             case .success(let indexedRouteResponse):
-                guard let strongSelf = self else {
+                guard let self = self else {
                     return
                 }
                 
                 // For demonstration purposes, simulate locations if the Simulate Navigation option is on.
                 let navigationService = MapboxNavigationService(indexedRouteResponse: indexedRouteResponse,
-                                                                customRoutingProvider: NavigationSettings.shared.directions,
+                                                                customRoutingProvider: self.routingProvider,
                                                                 credentials: NavigationSettings.shared.directions.credentials,
                                                                 simulating: simulationIsEnabled ? .always : .onPoorGPS)
                 let navigationOptions = NavigationOptions(navigationService: navigationService)
                 let navigationViewController = NavigationViewController(for: indexedRouteResponse,
                                                                         navigationOptions: navigationOptions)
                 navigationViewController.modalPresentationStyle = .fullScreen
-                navigationViewController.delegate = strongSelf
-                
-                strongSelf.present(navigationViewController, animated: true, completion: nil)
+                navigationViewController.delegate = self
+
+                self.present(navigationViewController, animated: true, completion: nil)
             }
         }
     }

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,32 +1,30 @@
 PODS:
-  - MapboxCommon (23.8.6)
-  - MapboxCoreMaps (10.16.4):
-    - MapboxCommon (~> 23.8)
-  - MapboxCoreNavigation (2.17.0):
-    - MapboxDirections (~> 2.11.1)
-    - MapboxMobileEvents (~> 1.0)
-    - MapboxNavigationNative (~> 160.0.0)
-  - MapboxDirections (2.11.1):
+  - MapboxCommon (23.9.2)
+  - MapboxCoreMaps (10.17.0):
+    - MapboxCommon (~> 23.9)
+  - MapboxCoreNavigation (2.18.1):
+    - MapboxDirections (~> 2.12.0)
+    - MapboxNavigationNative (~> 204.0.1)
+  - MapboxDirections (2.12.0):
     - Polyline (~> 5.0)
-    - Turf (~> 2.6.1)
-  - MapboxMaps (10.16.4):
-    - MapboxCommon (= 23.8.6)
-    - MapboxCoreMaps (= 10.16.4)
+    - Turf (~> 2.7.0)
+  - MapboxMaps (10.17.0):
+    - MapboxCommon (= 23.9.2)
+    - MapboxCoreMaps (= 10.17.0)
     - MapboxMobileEvents (= 1.0.10)
-    - Turf (~> 2.0)
+    - Turf (= 2.7.0)
   - MapboxMobileEvents (1.0.10)
-  - MapboxNavigation (2.17.0):
-    - MapboxCoreNavigation (= 2.17.0)
-    - MapboxMaps (~> 10.16.1)
-    - MapboxMobileEvents (~> 1.0)
+  - MapboxNavigation (2.18.1):
+    - MapboxCoreNavigation (= 2.18.1)
+    - MapboxMaps (~> 10.17.0)
     - MapboxSpeech (~> 2.0)
     - Solar-dev (~> 3.0)
-  - MapboxNavigationNative (160.0.1):
-    - MapboxCommon (~> 23.8)
+  - MapboxNavigationNative (204.0.1):
+    - MapboxCommon (~> 23.9)
   - MapboxSpeech (2.1.1)
   - Polyline (5.1.0)
   - Solar-dev (3.0.1)
-  - Turf (2.6.1)
+  - Turf (2.7.0)
 
 DEPENDENCIES:
   - MapboxCoreNavigation (~> 2.17)
@@ -48,18 +46,18 @@ SPEC REPOS:
     - Turf
 
 SPEC CHECKSUMS:
-  MapboxCommon: 90f76693dc02438acbb5ea9a5b266a4c0eb1c875
-  MapboxCoreMaps: 7b07d1ca8c454a4381daf09df901b9d6bf90bce0
-  MapboxCoreNavigation: fb7967e584e1fb81060fe0b1380fb36781e71f5e
-  MapboxDirections: 31d61b8369d5dde6f6828f72905ab9a7e054cd2c
-  MapboxMaps: cbb38845a9bf49b124f0e937975d560a4e01894e
+  MapboxCommon: 768660d6fca8193529ecf82eb6f5f9ae7a5acdf9
+  MapboxCoreMaps: be412ff97b16aa7820922c818115a9a0d8211caa
+  MapboxCoreNavigation: 73abe44e759cb93561da25eea8dd4bdc23a4b216
+  MapboxDirections: 4676f626df320732dcf74612223e568d39588320
+  MapboxMaps: 87ef0003e6db46e45e7a16939f29ae87e38e7ce2
   MapboxMobileEvents: de50b3a4de180dd129c326e09cd12c8adaaa46d6
-  MapboxNavigation: 2818173bfd07cfd3263776e5ff6664410083dcd7
-  MapboxNavigationNative: 539baa854733bcdb28f8c4a38528dd9ae94cee6d
+  MapboxNavigation: af43b0cf0af5f521fd84e42266579fcae121459a
+  MapboxNavigationNative: cf3640d04da6e67b701f76b1c502954286efee06
   MapboxSpeech: cd25ef99c3a3d2e0da72620ff558276ea5991a77
   Polyline: 2a1f29f87f8d9b7de868940f4f76deb8c678a5b1
   Solar-dev: 4612dc9878b9fed2667d23b327f1d4e54e16e8d0
-  Turf: 469ce2c3d22e5e8e4818d5a3b254699a5c89efa4
+  Turf: 13d1a92d969ca0311bbc26e8356cca178ce95da2
 
 PODFILE CHECKSUM: 9f24408adcadd22ff434a4f0f53b28f98ceaefae
 


### PR DESCRIPTION
[NAVIOS-1677](https://mapbox.atlassian.net/browse/NAVIOS-1677)

* Replaces `Directions.shared` usage with `MapboxRoutingProvider` in samples
* Replaces deprecated `RouteResponse` with `IndexedRouteResponse` usage in samples

[NAVIOS-1677]: https://mapbox.atlassian.net/browse/NAVIOS-1677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ