### PR TITLE
Resolve errors n Xcode 16 sample builds

### DIFF
--- a/Navigation-Examples/Examples/Route-Lines-Styling.swift
+++ b/Navigation-Examples/Examples/Route-Lines-Styling.swift
@@ -168,8 +168,7 @@ class RouteLinesStylingViewController: UIViewController {
 // MARK: - NavigationMapViewDelegate methods
 
 extension RouteLinesStylingViewController: NavigationMapViewDelegate {
-    
-    func lineWidthExpression(_ multiplier: Double = 1.0) -> Expression {
+    func lineWidthExpression(_ multiplier: Double = 1.0) -> MapboxMaps.Expression {
         let lineWidthExpression = Exp(.interpolate) {
             Exp(.linear)
             Exp(.zoom)


### PR DESCRIPTION
* Use `MapboxMaps.Expression` to distinguish it from `Foundation.Expression`